### PR TITLE
Add on-demand live process debugging

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -51,6 +51,22 @@ invoked as the session workspace. They do not reuse or replace the installed
 Rig daemon. When runtime source changes, the CLI fingerprints it and asks before
 restarting an older workspace daemon.
 
+## Live process debugging
+
+Run `/debug` in any interactive Rig session to start loopback-only Node
+inspectors for both the terminal UI and daemon. The command reports the current
+session, state directory, and both inspector URLs. In either inspector, evaluate
+`globalThis.__rigDebug` to start walking the live process state.
+
+Breakpoints suspend the process they target until it is resumed. Native
+inspector output from the daemon is written to the state directory's
+`server.log`. The TUI inherits Rig's stderr, so redirect it when starting Rig if
+you want to keep inspector messages out of the interface, for example
+`rig 2>rig-tui.log`. If stderr is still the terminal, `/debug` warns and asks for
+confirmation before starting. The inspectors use ephemeral ports bound to
+`127.0.0.1`; Node does not authenticate inspector connections, so do not expose
+those ports beyond the local machine.
+
 ## Validation
 
 Run these checks separately from the repository root:

--- a/packages/gym-tests/tests/debug_command_exposes_live_tui_and_daemon_state.test.ts
+++ b/packages/gym-tests/tests/debug_command_exposes_live_tui_and_daemon_state.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createGym, type Gym } from "@slopus/rig-gym";
+
+const running = new Set<Gym>();
+
+afterEach(async () => {
+    await Promise.all([...running].map((gym) => gym.dispose()));
+    running.clear();
+});
+
+describe("the debug command", () => {
+    it("reports both inspectors and exposes live TUI and daemon roots", async () => {
+        const gym = await createGym({
+            mode: "docker",
+            cols: 220,
+            entrypoint: [
+                "bash",
+                "-lc",
+                "exec node /app/packages/rig/dist/main.js 2>/workspace/tui-inspector.log",
+            ],
+            inference(request, callIndex) {
+                expect(callIndex).toBe(0);
+                expect(request.context.messages.at(-1)).toMatchObject({ role: "user" });
+                return { content: [{ text: "DEBUG_SEND_COMPLETED", type: "text" }] };
+            },
+            rows: 50,
+        });
+        running.add(gym);
+
+        submit(gym, "/debug");
+        const report = await gym.terminal.waitUntil(
+            (snapshot) =>
+                snapshot.text.includes("globalThis.__rigDebug") &&
+                snapshot.text.includes("TUI inspector") &&
+                snapshot.text.includes("Daemon inspector") &&
+                snapshot.text.includes("State directory") &&
+                snapshot.text.includes("Session"),
+            "the debug report",
+            30_000,
+        );
+        const inspectorUrls = [
+            ...new Set(report.text.match(/ws:\/\/127\.0\.0\.1:\d+\/[0-9a-f-]+/giu) ?? []),
+        ];
+        expect(inspectorUrls).toHaveLength(2);
+        expect(report.text).not.toContain("Daemon socket");
+        expect(report.text).not.toContain("Daemon registry");
+        expect(report.text).not.toContain("Client state");
+
+        const inspected = await gym.runInContainer("node", [
+            "--input-type=module",
+            "-e",
+            inspectDebugRootsScript,
+            ...inspectorUrls,
+        ]);
+        expect(inspected.stderr).toBe("");
+        const roots = JSON.parse(inspected.stdout) as Array<{
+            keys: string[];
+            kind: string;
+            sessionId?: string;
+        }>;
+        expect(roots.map((root) => root.kind).sort()).toEqual(["daemon", "tui"]);
+        expect(roots.find((root) => root.kind === "tui")).toMatchObject({
+            keys: expect.arrayContaining([
+                "agent",
+                "app",
+                "connection",
+                "eventFollowerController",
+                "sessionId",
+            ]),
+            sessionId: expect.any(String),
+        });
+        expect(roots.find((root) => root.kind === "daemon")).toMatchObject({
+            keys: expect.arrayContaining(["paths", "server", "store"]),
+        });
+        await expect(gym.readFile("tui-inspector.log")).resolves.toContain("Debugger listening");
+        const uid = await gym.runInContainer("id", ["-u"]);
+        const daemonLog = await gym.runInContainer("cat", [
+            `/tmp/rig-${uid.stdout.trim()}/server.log`,
+        ]);
+        expect(daemonLog.stdout).toContain("Debugger listening");
+        const afterAttach = await gym.terminal.snapshot();
+        expect(afterAttach.text).not.toContain("Debugger attached");
+        expect(afterAttach.text).not.toContain("Debugger ending");
+
+        submit(gym, "DEBUG_SEND_VISIBLE");
+        const completed = await gym.terminal.waitUntil(
+            (snapshot) =>
+                snapshot.text.includes("DEBUG_SEND_VISIBLE") &&
+                snapshot.text.includes("DEBUG_SEND_COMPLETED"),
+            "a visible message and response after debugger attachment",
+            30_000,
+        );
+        expect(completed.text).not.toContain("write EPIPE");
+    }, 90_000);
+});
+
+function submit(gym: Gym, text: string): void {
+    gym.terminal.write(text);
+    gym.terminal.press("enter");
+}
+
+const inspectDebugRootsScript = String.raw`
+const urls = process.argv.slice(1);
+
+function evaluate(url) {
+    return new Promise((resolve, reject) => {
+        const socket = new WebSocket(url);
+        const timeout = setTimeout(() => {
+            socket.close();
+            reject(new Error("inspector evaluation timed out"));
+        }, 10_000);
+        socket.onerror = () => reject(new Error("inspector connection failed: " + url));
+        socket.onopen = () => {
+            socket.send(JSON.stringify({
+                id: 1,
+                method: "Runtime.evaluate",
+                params: {
+                    expression: "({ kind: globalThis.__rigDebug?.kind, keys: Object.keys(globalThis.__rigDebug ?? {}), sessionId: globalThis.__rigDebug?.sessionId })",
+                    returnByValue: true,
+                },
+            }));
+        };
+        socket.onmessage = (event) => {
+            const message = JSON.parse(String(event.data));
+            if (message.id !== 1) return;
+            clearTimeout(timeout);
+            socket.close();
+            if (message.error || message.result?.exceptionDetails) {
+                reject(new Error(JSON.stringify(message)));
+                return;
+            }
+            resolve(message.result.result.value);
+        };
+    });
+}
+
+console.log(JSON.stringify(await Promise.all(urls.map(evaluate))));
+`;

--- a/packages/rig/sources/app/CodingAssistantApp.test.ts
+++ b/packages/rig/sources/app/CodingAssistantApp.test.ts
@@ -202,6 +202,65 @@ describe("CodingAssistantApp", () => {
         await app.waitForIdle();
     });
 
+    it("warns before starting inspectors when TUI stderr is the terminal", async () => {
+        const model = defineModel({
+            id: "openai/gpt-test",
+            name: "GPT Test",
+            thinkingLevels: ["off"],
+            defaultThinkingLevel: "off",
+        });
+        const provider = defineProvider({
+            id: "codex",
+            models: [model],
+            stream() {
+                return streamText("unused");
+            },
+        });
+        const harness = createJustBashToolHarness();
+        const startInspectors = vi.fn(async () => ({
+            serverInspectorUrl: "ws://127.0.0.1:42002/daemon",
+            tuiInspectorUrl: "ws://127.0.0.1:42001/tui",
+        }));
+        const app = new CodingAssistantApp({
+            agent: new Agent({
+                provider,
+                modelId: model.id,
+                context: harness.context,
+                printToConsole: false,
+            }),
+            cwd: harness.context.fs.cwd,
+            debugInfo: {
+                sessionId: "session-debug-1",
+                startInspectors,
+                stateDirectory: "/state/rig",
+                tuiStderrIsTTY: true,
+            },
+            processManager: new NativeProcessManager(),
+            tui: fakeTui(),
+        });
+
+        submit(app, "/debug");
+
+        const warning = stripAnsi(app.render(120).join("\n"));
+        expect(warning).toContain("Start live debugging?");
+        expect(warning).toContain("stderr is still this terminal");
+        expect(warning).toContain("Redirect stderr before starting");
+        expect(startInspectors).not.toHaveBeenCalled();
+
+        app.handleInput("\r");
+        await vi.waitFor(() => expect(startInspectors).toHaveBeenCalledOnce());
+
+        const rendered = stripAnsi(app.render(120).join("\n"));
+        expect(rendered).toContain("Debug");
+        expect(rendered).toContain("globalThis.__rigDebug");
+        expect(rendered).toContain("session-debug-1");
+        expect(rendered).toContain("/state/rig");
+        expect(rendered).toContain("ws://127.0.0.1:42001/tui");
+        expect(rendered).toContain("ws://127.0.0.1:42002/daemon");
+        expect(rendered).not.toContain("Daemon socket");
+        expect(rendered).not.toContain("Client state");
+    });
+
     it("renders the startup frame and Codex-style empty composer", () => {
         const model = defineModel({
             id: "openai/gpt-test",
@@ -1339,9 +1398,7 @@ describe("CodingAssistantApp", () => {
         });
 
         const updated = app.render(80);
-        expect(updated.slice(0, transcriptLine + 1)).toEqual(
-            initial.slice(0, transcriptLine + 1),
-        );
+        expect(updated.slice(0, transcriptLine + 1)).toEqual(initial.slice(0, transcriptLine + 1));
     });
 
     it("renders every markdown table row after streaming finishes", () => {
@@ -1373,8 +1430,9 @@ describe("CodingAssistantApp", () => {
         const table = [
             "| Name | Value |",
             "| --- | --- |",
-            ...Array.from({ length: 30 }, (_, index) =>
-                `| row-${String(index + 1)} | value-${String(index + 1)} |`,
+            ...Array.from(
+                { length: 30 },
+                (_, index) => `| row-${String(index + 1)} | value-${String(index + 1)} |`,
             ),
         ].join("\n");
         const partial: AssistantMessage = {

--- a/packages/rig/sources/app/CodingAssistantApp.ts
+++ b/packages/rig/sources/app/CodingAssistantApp.ts
@@ -180,11 +180,26 @@ export interface CodingAssistantAppOptions {
     unregisterSecret?: (id: string) => boolean | Promise<boolean>;
     detachSecret?: (id: string, scope: SecretAttachmentScope) => void | Promise<void>;
     durableGlobalEventQueue?: boolean;
+    debugInfo?: AppDebugInfo;
     showReasoning?: boolean;
     showUsage?: boolean;
     startupStatus?: StartupStatusCardModel;
     version?: string;
     theme?: TerminalTheme;
+}
+
+export interface AppDebugInfo {
+    serverInspectorUrl?: string;
+    sessionId: string;
+    startInspectors: () => Promise<AppDebugInspectorUrls>;
+    stateDirectory: string;
+    tuiInspectorUrl?: string;
+    tuiStderrIsTTY: boolean;
+}
+
+interface AppDebugInspectorUrls {
+    serverInspectorUrl: string;
+    tuiInspectorUrl: string;
 }
 
 function addUsage(left: Usage, right: Usage): Usage {
@@ -391,6 +406,8 @@ export class CodingAssistantApp implements Component, Focusable {
     #streamedToolCallEntries = new Set<AppTranscriptEntry>();
     #streamingThinkingEntryIds = new Set<string>();
     #deferredTurnSeparator = false;
+    readonly #debugInfo: AppDebugInfo | undefined;
+    #debugInspectorStart: Promise<AppDebugInspectorUrls> | undefined;
     #pendingSubagentCompletionIds = new Set<string>();
     #recordedSubagentCompletionIds = new Set<string>();
     #renderedCompletionNotices = new Map<string, number>();
@@ -426,6 +443,7 @@ export class CodingAssistantApp implements Component, Focusable {
         this.#sessionBacked = options.sessionBacked ?? false;
         this.#completionChime = options.completionChime ?? false;
         this.#durableGlobalEventQueue = options.durableGlobalEventQueue ?? false;
+        this.#debugInfo = options.debugInfo;
         this.#showReasoning = options.showReasoning ?? false;
         this.#showUsage = options.showUsage ?? false;
         this.#modelLocked = options.modelLocked ?? !options.agent.canChangeModel;
@@ -639,10 +657,7 @@ export class CodingAssistantApp implements Component, Focusable {
             } else {
                 this.#recordUserInput(event.createdAt);
                 if (
-                    this.#reconcileSubmittedUserEntry(
-                        event.data.message.id,
-                        event.data.displayText,
-                    )
+                    this.#reconcileSubmittedUserEntry(event.data.message.id, event.data.displayText)
                 ) {
                     return;
                 }
@@ -1617,6 +1632,11 @@ export class CodingAssistantApp implements Component, Focusable {
             return true;
         }
 
+        if (prompt === "/debug") {
+            this.#handleDebugCommand();
+            return true;
+        }
+
         if (prompt === "/permissions" || prompt === "/permission") {
             this.#openPermissionsMenu();
             return true;
@@ -1703,6 +1723,103 @@ export class CodingAssistantApp implements Component, Focusable {
         }
 
         return false;
+    }
+
+    #handleDebugCommand(): void {
+        const debug = this.#debugInfo;
+        if (debug === undefined) {
+            this.#appendDebugInfo();
+            return;
+        }
+        if (debug.tuiInspectorUrl === undefined && debug.tuiStderrIsTTY) {
+            const finish = (start: boolean) => {
+                this.#closeSelectionPanel();
+                if (start) {
+                    void this.#startInspectorsAndReport();
+                } else {
+                    this.#appendEntry({
+                        role: "event",
+                        text: "Live debugging was not started.",
+                        title: "Debug",
+                    });
+                }
+            };
+            this.#showSelectionPanel(
+                createSelectionPanel({
+                    items: [
+                        {
+                            description: "Open local debugger ports for this TUI and daemon.",
+                            label: "Start inspectors",
+                            value: "start",
+                        },
+                        {
+                            description: "Leave live debugging off.",
+                            label: "Cancel",
+                            value: "cancel",
+                        },
+                    ],
+                    onCancel: () => finish(false),
+                    onSelect: (item) => finish(item.value === "start"),
+                    subtitle:
+                        "The TUI's stderr is still this terminal. Node will write debugger connection messages here and may disturb the interface. Redirect stderr before starting when possible.",
+                    theme: this.#theme,
+                    title: "Start live debugging?",
+                }),
+            );
+            return;
+        }
+        void this.#startInspectorsAndReport();
+    }
+
+    async #startInspectorsAndReport(): Promise<void> {
+        const debug = this.#debugInfo;
+        if (debug === undefined) {
+            this.#appendDebugInfo();
+            return;
+        }
+        try {
+            if (debug.tuiInspectorUrl === undefined || debug.serverInspectorUrl === undefined) {
+                const starting = this.#debugInspectorStart ?? debug.startInspectors();
+                this.#debugInspectorStart = starting;
+                const urls = await starting;
+                debug.serverInspectorUrl = urls.serverInspectorUrl;
+                debug.tuiInspectorUrl = urls.tuiInspectorUrl;
+                if (this.#debugInspectorStart === starting) this.#debugInspectorStart = undefined;
+            }
+            this.#appendDebugInfo();
+        } catch (error) {
+            this.#debugInspectorStart = undefined;
+            this.#appendEntry({
+                role: "error",
+                text: errorToMessage(error),
+                title: "Debug",
+            });
+            this.#requestRender();
+        }
+    }
+
+    #appendDebugInfo(): void {
+        const debug = this.#debugInfo;
+        const details =
+            debug === undefined
+                ? [{ label: "Session", reason: "Unavailable" }]
+                : [
+                      { label: "Session", reason: debug.sessionId },
+                      { label: "State directory", reason: debug.stateDirectory },
+                      { label: "TUI inspector", reason: debug.tuiInspectorUrl ?? "Off" },
+                      { label: "Daemon inspector", reason: debug.serverInspectorUrl ?? "Off" },
+                      {
+                          label: "Live state",
+                          reason: "Evaluate globalThis.__rigDebug in either inspector",
+                      },
+                  ];
+        this.#appendEntry({
+            noticeChildren: details,
+            role: "event",
+            text: "Open either inspector and evaluate globalThis.__rigDebug to walk the live process state.",
+            title: "Debug",
+        });
+        this.#requestRender();
     }
 
     #handleFastCommand(prompt: string): void {

--- a/packages/rig/sources/app/createSlashCommands.test.ts
+++ b/packages/rig/sources/app/createSlashCommands.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from "vitest";
 import { createSlashCommands } from "./createSlashCommands.js";
 
 describe("createSlashCommands", () => {
+    it("offers live process debugging", () => {
+        expect(createSlashCommands().find((command) => command.value === "debug")).toMatchObject({
+            label: "/debug",
+            description: "Start live process debugging.",
+        });
+    });
+
     it("describes secret attachments without limiting them to the session scope", () => {
         expect(createSlashCommands().find((command) => command.value === "secrets")).toMatchObject({
             label: "/secrets",

--- a/packages/rig/sources/app/createSlashCommands.ts
+++ b/packages/rig/sources/app/createSlashCommands.ts
@@ -51,6 +51,12 @@ export function createSlashCommands(
             aliases: ["todos"],
         },
         {
+            value: "debug",
+            label: "/debug",
+            description: "Start live process debugging.",
+            aliases: [],
+        },
+        {
             value: "usage",
             label: "/usage",
             description: "Show token usage for this session.",
@@ -124,7 +130,7 @@ export function createSlashCommands(
         },
     ];
     if (options.workflowsEnabled !== false) {
-        commands.splice(8, 0, {
+        commands.splice(9, 0, {
             value: "workflows",
             label: "/workflows",
             description: "Open the live workflow monitor.",

--- a/packages/rig/sources/app/runApp.ts
+++ b/packages/rig/sources/app/runApp.ts
@@ -29,7 +29,12 @@ import { resolveStartupProviderQuota } from "./resolveStartupProviderQuota.js";
 import { RigTerminal } from "./RigTerminal.js";
 import { sessionAgentFooterLabel } from "./sessionAgentFooterLabel.js";
 import { StartupStatusApp } from "./StartupStatusApp.js";
-import { getDebugRootDirectory } from "../debug/index.js";
+import {
+    getDebugRootDirectory,
+    getNodeInspectorUrl,
+    openNodeInspector,
+    registerRigDebugRoot,
+} from "../debug/index.js";
 
 export interface RunAppOptions {
     apiKey?: string;
@@ -209,6 +214,7 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
             ? []
             : [{ text: projectMcpNotice, title: "Project MCP needs trust" }]),
     ];
+    const tuiInspectorUrl = getNodeInspectorUrl();
     const app = new CodingAssistantApp({
         ...(activeAgentLabel === undefined ? {} : { activeAgentLabel }),
         agent,
@@ -291,6 +297,19 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
         sessionBacked: true,
         completionChime,
         durableGlobalEventQueue,
+        debugInfo: {
+            sessionId: session.session.id,
+            startInspectors: async () => {
+                const server = await localServer.client.startInspector();
+                return {
+                    serverInspectorUrl: server.inspectorUrl,
+                    tuiInspectorUrl: openNodeInspector(),
+                };
+            },
+            stateDirectory: localServer.paths.directory,
+            tuiStderrIsTTY: process.stderr.isTTY === true,
+            ...(tuiInspectorUrl === undefined ? {} : { tuiInspectorUrl }),
+        },
         showReasoning,
         showUsage,
         startupStatus: createStartupStatusCardModel({
@@ -324,6 +343,16 @@ export async function runApp(options: RunAppOptions = {}): Promise<void> {
     });
     startup.stop();
     const followController = new AbortController();
+    registerRigDebugRoot({
+        agent,
+        app,
+        connection: localServer,
+        eventFollowerController: followController,
+        kind: "tui",
+        sessionId: session.session.id,
+        terminal,
+        tui,
+    });
     const observedChimeEvents = new Set<string>();
     const lastHistoryEventId = history.events.at(-1)?.id ?? session.session.lastEventId;
     void localServer.client.watchSessionEvents({

--- a/packages/rig/sources/client/ProtocolHttpClient.ts
+++ b/packages/rig/sources/client/ProtocolHttpClient.ts
@@ -46,6 +46,7 @@ import type {
     SecretSessionResponse,
     SessionEvent,
     ShutdownServerResponse,
+    StartInspectorResponse,
     SetGoalRequest,
     SteerMessageRequest,
     SteerMessageResponse,
@@ -431,6 +432,10 @@ export class ProtocolHttpClient {
 
     shutdown(): Promise<ShutdownServerResponse> {
         return this.#requestJson("POST", "/shutdown");
+    }
+
+    startInspector(): Promise<StartInspectorResponse> {
+        return this.#requestJson("POST", "/debug/inspector");
     }
 
     submitMessage(

--- a/packages/rig/sources/debug/getNodeInspectorUrl.ts
+++ b/packages/rig/sources/debug/getNodeInspectorUrl.ts
@@ -1,0 +1,5 @@
+import { url } from "node:inspector";
+
+export function getNodeInspectorUrl(): string | undefined {
+    return url();
+}

--- a/packages/rig/sources/debug/index.ts
+++ b/packages/rig/sources/debug/index.ts
@@ -3,4 +3,7 @@ export type { DebugLogOptions } from "./DebugLog.js";
 export { createDebugProvider } from "./createDebugProvider.js";
 export type { CreateDebugProviderOptions } from "./createDebugProvider.js";
 export { createRequestDebugDirectory } from "./createRequestDebugDirectory.js";
+export { getNodeInspectorUrl } from "./getNodeInspectorUrl.js";
 export { getDebugRootDirectory } from "./getDebugRootDirectory.js";
+export { openNodeInspector } from "./openNodeInspector.js";
+export { registerRigDebugRoot, type RigDebugRoot } from "./registerRigDebugRoot.js";

--- a/packages/rig/sources/debug/openNodeInspector.ts
+++ b/packages/rig/sources/debug/openNodeInspector.ts
@@ -1,0 +1,11 @@
+import { open, url } from "node:inspector";
+
+export function openNodeInspector(): string {
+    const activeUrl = url();
+    if (activeUrl !== undefined) return activeUrl;
+
+    open(0, "127.0.0.1", false);
+    const openedUrl = url();
+    if (openedUrl === undefined) throw new Error("Node inspector did not start.");
+    return openedUrl;
+}

--- a/packages/rig/sources/debug/registerRigDebugRoot.ts
+++ b/packages/rig/sources/debug/registerRigDebugRoot.ts
@@ -1,0 +1,13 @@
+export interface RigDebugRoot {
+    kind: "daemon" | "tui";
+    [name: string]: unknown;
+}
+
+export function registerRigDebugRoot(root: RigDebugRoot): void {
+    Object.defineProperty(globalThis, "__rigDebug", {
+        configurable: true,
+        enumerable: false,
+        value: root,
+        writable: true,
+    });
+}

--- a/packages/rig/sources/protocol/SessionProtocol.ts
+++ b/packages/rig/sources/protocol/SessionProtocol.ts
@@ -365,6 +365,10 @@ export interface ShutdownServerResponse {
     shuttingDown: boolean;
 }
 
+export interface StartInspectorResponse {
+    inspectorUrl: string;
+}
+
 export interface GlobalEventQueueEntry {
     cursor: number;
     event: SessionEvent;

--- a/packages/rig/sources/protocol/index.ts
+++ b/packages/rig/sources/protocol/index.ts
@@ -104,6 +104,7 @@ export type {
     StopWorkflowResponse,
     SessionTitleStatus,
     ShutdownServerResponse,
+    StartInspectorResponse,
     SubmitMessageRequest,
     SubmitMessageResponse,
     SteerMessageRequest,

--- a/packages/rig/sources/server/createProtocolHttpServer.test.ts
+++ b/packages/rig/sources/server/createProtocolHttpServer.test.ts
@@ -670,6 +670,21 @@ describe("createProtocolHttpServer", () => {
         }
     });
 
+    it("starts the daemon inspector through the authenticated local protocol", async () => {
+        const onStartInspector = vi.fn(async () => ({
+            inspectorUrl: "ws://127.0.0.1:42002/daemon",
+        }));
+        const { client, close } = await startServer({ onStartInspector });
+        try {
+            await expect(client.startInspector()).resolves.toEqual({
+                inspectorUrl: "ws://127.0.0.1:42002/daemon",
+            });
+            expect(onStartInspector).toHaveBeenCalledOnce();
+        } finally {
+            await close();
+        }
+    });
+
     it("enables and disables the durable queue through daemon configuration", async () => {
         const store = new PersistentSessionStore({ databasePath: ":memory:" });
         const { client, close } = await startServer({
@@ -1553,6 +1568,7 @@ async function startServer(
             enabled: boolean,
         ) => GlobalEventQueue | undefined | Promise<GlobalEventQueue | undefined>;
         onShutdown?: () => void;
+        onStartInspector?: () => Promise<{ inspectorUrl: string }>;
         store?: SessionStore;
         taskDrain?: TrackedTaskDrain;
     } = {},
@@ -1577,6 +1593,9 @@ async function startServer(
             ? {}
             : { getProviderQuota: options.getProviderQuota }),
         ...(options.onShutdown !== undefined ? { onShutdown: options.onShutdown } : {}),
+        ...(options.onStartInspector !== undefined
+            ? { onStartInspector: options.onStartInspector }
+            : {}),
         ...(options.onDurableGlobalEventQueueChange === undefined
             ? {}
             : {

--- a/packages/rig/sources/server/createProtocolHttpServer.ts
+++ b/packages/rig/sources/server/createProtocolHttpServer.ts
@@ -40,6 +40,7 @@ import type {
     SessionEvent,
     SetGoalRequest,
     ShutdownServerResponse,
+    StartInspectorResponse,
     SteerMessageResponse,
     StopWorkflowResponse,
     SubmitMessageResponse,
@@ -94,6 +95,7 @@ export interface ProtocolHttpServerOptions {
         enabled: boolean,
     ) => GlobalEventQueue | undefined | Promise<GlobalEventQueue | undefined>;
     onShutdown?: () => void;
+    onStartInspector?: () => StartInspectorResponse | Promise<StartInspectorResponse>;
     store?: SessionStore;
     taskDrain?: TaskDrain;
     secrets?: readonly SecretRegistration[];
@@ -116,6 +118,7 @@ export function createProtocolHttpServer(
     const runtimeConfig: ProtocolServerRuntimeConfig = {
         globalEventQueue: options.globalEventQueue,
         onDurableGlobalEventQueueChange: options.onDurableGlobalEventQueueChange,
+        onStartInspector: options.onStartInspector,
     };
 
     attachRemoteTerminalWebSocketServer({ server, store, token: options.token });
@@ -173,6 +176,7 @@ interface ProtocolServerRuntimeConfig {
               enabled: boolean,
           ) => GlobalEventQueue | undefined | Promise<GlobalEventQueue | undefined>)
         | undefined;
+    onStartInspector: (() => StartInspectorResponse | Promise<StartInspectorResponse>) | undefined;
 }
 
 async function handleRequest(
@@ -217,6 +221,15 @@ async function handleRequest(
             shuttingDown: true,
         });
         setImmediate(() => onShutdown?.());
+        return;
+    }
+
+    if (request.method === "POST" && route.name === "debug-inspector") {
+        if (runtimeConfig.onStartInspector === undefined) {
+            sendJson(response, 409, { error: "This daemon cannot start a debugger." });
+            return;
+        }
+        sendJson<StartInspectorResponse>(response, 200, await runtimeConfig.onStartInspector());
         return;
     }
 
@@ -1010,6 +1023,7 @@ function matchRoute(pathname: string):
               | "global-events-trim"
               | "external-tool-calls"
               | "config"
+              | "debug-inspector"
               | "health"
               | "messages"
               | "models"
@@ -1059,6 +1073,7 @@ function matchRoute(pathname: string):
     | undefined {
     if (pathname === "/health") return { name: "health" };
     if (pathname === "/config") return { name: "config" };
+    if (pathname === "/debug/inspector") return { name: "debug-inspector" };
     if (pathname === "/events") return { name: "global-events" };
     if (pathname === "/events/stream") return { name: "global-events-stream" };
     if (pathname === "/events/trim") return { name: "global-events-trim" };
@@ -1187,6 +1202,7 @@ function isMutatingProtocolRequest(request: IncomingMessage): boolean {
     const route = matchRoute(url.pathname);
     if (route === undefined) return false;
     if (route.name === "config") return request.method === "PATCH";
+    if (route.name === "debug-inspector") return request.method === "POST";
     if (route.name === "global-events-trim") return request.method === "POST";
     if (route.name === "secret-registrations") return request.method === "POST";
     if (route.name === "secret-registration") return request.method === "DELETE";

--- a/packages/rig/sources/server/runLocalProtocolServer.ts
+++ b/packages/rig/sources/server/runLocalProtocolServer.ts
@@ -19,6 +19,7 @@ import { createProviderQuotaService } from "../providers/createProviderQuotaServ
 import { createCodingAssistantAgent } from "../runtime/createCodingAssistantAgent.js";
 import { getDaemonIdentity } from "../daemon/index.js";
 import { errorToMessage } from "../errorToMessage.js";
+import { getNodeInspectorUrl, openNodeInspector, registerRigDebugRoot } from "../debug/index.js";
 
 export interface RunLocalProtocolServerOptions {
     socketPath?: string;
@@ -31,6 +32,7 @@ export async function runLocalProtocolServer(
     const paths = getEnvironmentLocalServerPaths();
     const socketPath = options.socketPath ?? paths.socketPath;
     const tokenPath = options.tokenPath ?? paths.tokenPath;
+    const startedAt = new Date().toISOString();
     await prepareLocalServerDirectory(paths.directory);
     const token = await readLocalServerToken(tokenPath);
     await removeStaleSocket(socketPath);
@@ -75,6 +77,15 @@ export async function runLocalProtocolServer(
         token,
     });
     const server = createServer(startupRequestListener);
+    const writeServerRegistry = () => {
+        const inspectorUrl = getNodeInspectorUrl();
+        return writeRegistry(paths.registryPath, {
+            ...(inspectorUrl === undefined ? {} : { inspectorUrl }),
+            pid: process.pid,
+            socketPath,
+            startedAt,
+        });
+    };
     let initialization = Promise.resolve();
     const reportStartupError = (error: unknown) => {
         if (stopping) return;
@@ -103,11 +114,7 @@ export async function runLocalProtocolServer(
                 await stopped;
                 return;
             }
-            await writeRegistry(paths.registryPath, {
-                pid: process.pid,
-                socketPath,
-                startedAt: new Date().toISOString(),
-            });
+            await writeServerRegistry();
         } catch (error) {
             reportStartupError(error);
             await stopped;
@@ -163,6 +170,12 @@ export async function runLocalProtocolServer(
             modelCatalog,
             taskDrain,
         });
+        registerRigDebugRoot({
+            kind: "daemon",
+            paths,
+            server,
+            store,
+        });
         if (stopping) {
             taskDrain.beginClose();
             return;
@@ -181,6 +194,11 @@ export async function runLocalProtocolServer(
                 onDurableGlobalEventQueueChange: async (enabled) => {
                     await writeDaemonSettings({ durableGlobalEventQueue: enabled });
                     return store?.setDurableGlobalEventQueue(enabled);
+                },
+                onStartInspector: async () => {
+                    const inspectorUrl = openNodeInspector();
+                    await writeServerRegistry();
+                    return { inspectorUrl };
                 },
                 onShutdown: stopServer,
                 store,


### PR DESCRIPTION
## Why?

When an intermittent Rig failure happens, `/debug` turns the still-running TUI and daemon into live evidence. Another agent can attach, inspect state and call stacks, and troubleshoot the actual broken processes instead of reconstructing them from logs.

## Core architectural change

```text
rig
└─ TUI
   └─ daemon

/debug
├─ starts TUI inspector                 stderr → inherited
└─ calls daemon over authenticated socket
   └─ starts daemon inspector           stderr → server.log
```

Both inspectors bind ephemeral ports on `127.0.0.1`. The inspector protocol itself is unauthenticated. If TUI stderr is still a TTY, Rig warns and requires confirmation before Node can write its inspector banner into the interface.

## Impact

- Before `/debug`: 0 extra processes and 0 inspector ports.
- After `/debug`: 2 loopback inspector ports, plus compact session, state-directory, and connection pointers.
- No launcher, startup flag, or heavy-session benchmark belongs in this feature; the reusable heavy Gym is isolated in #4.

| Area | Added | Removed |
|---|---:|---:|
| TUI command and wiring | 158 | 6 |
| Daemon protocol and control | 49 | 5 |
| Inspector helpers and live roots | 32 | 0 |
| Tests | 228 | 5 |
| Docs | 16 | 0 |
| **Total** | **483** | **16** |
