### PR TITLE
feat(happy): support managed workspaces

### DIFF
--- a/packages/rig/sources/development/configureDevelopmentEnvironment.test.ts
+++ b/packages/rig/sources/development/configureDevelopmentEnvironment.test.ts
@@ -14,15 +14,14 @@ describe("configureDevelopmentEnvironment", () => {
 
         expect(environment).toEqual({
             RIG_DEVELOPMENT_BUILD_ID: "existing-build",
-            RIG_DISABLE_HAPPY_SYNC: "1",
             RIG_SERVER_DIRECTORY: "/workspace/rig/.rig-dev",
         });
     });
 
-    it("preserves an explicit Happy development opt-in", async () => {
+    it("preserves an explicit Happy development opt-out", async () => {
         const environment = {
             RIG_DEVELOPMENT_BUILD_ID: "existing-build",
-            RIG_DISABLE_HAPPY_SYNC: "0",
+            RIG_DISABLE_HAPPY_SYNC: "1",
         };
 
         await configureDevelopmentEnvironment({
@@ -30,7 +29,7 @@ describe("configureDevelopmentEnvironment", () => {
             repositoryRoot: "/workspace/rig",
         });
 
-        expect(environment.RIG_DISABLE_HAPPY_SYNC).toBe("0");
+        expect(environment.RIG_DISABLE_HAPPY_SYNC).toBe("1");
     });
 
     it("replaces inherited global Rig paths with checkout-local development state", async () => {
@@ -48,7 +47,6 @@ describe("configureDevelopmentEnvironment", () => {
 
         expect(environment).toEqual({
             RIG_DEVELOPMENT_BUILD_ID: "existing-build",
-            RIG_DISABLE_HAPPY_SYNC: "1",
             RIG_SERVER_DIRECTORY: "/workspace/rig/.rig-dev",
         });
         expect(getEnvironmentLocalServerPaths(environment, 501)).toEqual({

--- a/packages/rig/sources/development/configureDevelopmentEnvironment.ts
+++ b/packages/rig/sources/development/configureDevelopmentEnvironment.ts
@@ -8,7 +8,10 @@ export async function configureDevelopmentEnvironment(options: {
 }): Promise<void> {
     const environment = options.environment ?? process.env;
     const developmentDirectory = join(options.repositoryRoot, ".rig-dev");
-    environment.RIG_DISABLE_HAPPY_SYNC ??= "1";
+    // Happy sync runs in development exactly like in the released CLI: without
+    // it a rig-dev daemon never registers a Happy machine, so the Happy app
+    // cannot create sessions against the checkout — the main thing a Happy
+    // integration developer needs. Opt out with RIG_DISABLE_HAPPY_SYNC=1.
     // A terminal opened by Rig may inherit the running daemon's paths. Development must replace
     // those coordinates or it can mistake the global daemon for this checkout's stale daemon and
     // shut it down. The directory derives every daemon-owned path, including the SQLite database.

--- a/packages/rig/sources/happy/HappyMachineClient.ts
+++ b/packages/rig/sources/happy/HappyMachineClient.ts
@@ -1,5 +1,7 @@
 import { io, type Socket } from "socket.io-client";
 
+import { Value } from "@sinclair/typebox/value";
+
 import type { ModelCatalog } from "../protocol/index.js";
 import { isDatabaseFailure } from "../persistence/isDatabaseFailure.js";
 import { readPackageVersion } from "../readPackageVersion.js";
@@ -8,11 +10,14 @@ import { decryptHappyPayload, encryptHappyPayload, wrapHappyDataKey } from "./ha
 import type {
     HappyConnectionConfiguration,
     HappyListWorkspacesResult,
+    HappySpawnSessionRequest,
     HappySpawnSessionResult,
 } from "./types.js";
+import { happySpawnSessionRequestSchema } from "./types.js";
 
 const HTTP_TIMEOUT_MS = 15_000;
 const RETRY_INTERVAL_MS = 5_000;
+const MAX_REMEMBERED_SPAWN_REQUESTS = 1_000;
 const KEEP_ALIVE_INTERVAL_MS = 20_000;
 
 interface HappyMachineSocket {
@@ -48,6 +53,8 @@ export class HappyMachineClient {
     #closed = false;
     readonly #closeController = new AbortController();
     #keepAliveTimer: NodeJS.Timeout | undefined;
+    readonly #spawnRequestFingerprints = new Map<string, string>();
+    readonly #pendingSpawns = new Map<string, Promise<HappySpawnSessionResult>>();
     #retryTimer: NodeJS.Timeout | undefined;
     #socket: HappyMachineSocket | undefined;
 
@@ -70,6 +77,8 @@ export class HappyMachineClient {
         this.#closeController.abort();
         if (this.#keepAliveTimer !== undefined) clearInterval(this.#keepAliveTimer);
         if (this.#retryTimer !== undefined) clearTimeout(this.#retryTimer);
+        this.#spawnRequestFingerprints.clear();
+        this.#pendingSpawns.clear();
         this.#socket?.disconnect();
         this.#socket = undefined;
     }
@@ -181,7 +190,7 @@ export class HappyMachineClient {
                 try {
                     response = isList
                         ? await this.#listWorkspaces!(params)
-                        : await this.#spawnSession(params, this.#closeController.signal);
+                        : await this.#spawnOnce(params);
                 } catch (error) {
                     if (isDatabaseFailure(error)) throw error;
                     response = {
@@ -195,6 +204,44 @@ export class HappyMachineClient {
             }
         }
         callback(encode(key, variant, response));
+    }
+
+    async #spawnOnce(params: unknown): Promise<HappySpawnSessionResult> {
+        const request = readSpawnRequest(params);
+        if (request === undefined) {
+            return await this.#spawnSession(params, this.#closeController.signal);
+        }
+        const clientRequestId = request.clientRequestId;
+        const fingerprint = spawnRequestFingerprint(request);
+        const rememberedFingerprint = this.#spawnRequestFingerprints.get(clientRequestId);
+        if (rememberedFingerprint !== undefined && rememberedFingerprint !== fingerprint) {
+            return {
+                errorMessage:
+                    "This client request ID was already used for a different session request.",
+                type: "error",
+            };
+        }
+        if (rememberedFingerprint === undefined) {
+            if (this.#spawnRequestFingerprints.size >= MAX_REMEMBERED_SPAWN_REQUESTS) {
+                const oldest = this.#spawnRequestFingerprints.keys().next().value;
+                if (oldest !== undefined) this.#spawnRequestFingerprints.delete(oldest);
+            }
+            this.#spawnRequestFingerprints.set(clientRequestId, fingerprint);
+        }
+        const existing = this.#pendingSpawns.get(clientRequestId);
+        if (existing !== undefined) return await existing;
+
+        const spawn = Promise.resolve().then(() =>
+            this.#spawnSession(params, this.#closeController.signal),
+        );
+        this.#pendingSpawns.set(clientRequestId, spawn);
+        try {
+            return await spawn;
+        } finally {
+            if (this.#pendingSpawns.get(clientRequestId) === spawn) {
+                this.#pendingSpawns.delete(clientRequestId);
+            }
+        }
     }
 
     #scheduleRetry(): void {
@@ -322,4 +369,25 @@ function readMachine(value: unknown): {
 
 function isRecord(value: unknown): value is Record<string, any> {
     return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readSpawnRequest(params: unknown): HappySpawnSessionRequest | undefined {
+    if (!Value.Check(happySpawnSessionRequestSchema, params)) return undefined;
+    return params as HappySpawnSessionRequest;
+}
+
+function spawnRequestFingerprint(request: HappySpawnSessionRequest): string {
+    // Directory approval intentionally is not part of the fingerprint: Happy
+    // retries the same request ID after the user approves that one transition.
+    return JSON.stringify([
+        request.agent,
+        request.directory,
+        request.effort ?? null,
+        request.modelId ?? null,
+        request.permissionMode ?? null,
+        request.providerId ?? null,
+        request.type,
+        request.worktree?.type ?? null,
+        request.worktree?.name ?? null,
+    ]);
 }

--- a/packages/rig/sources/happy/HappyMachineClient.ts
+++ b/packages/rig/sources/happy/HappyMachineClient.ts
@@ -5,7 +5,11 @@ import { isDatabaseFailure } from "../persistence/isDatabaseFailure.js";
 import { readPackageVersion } from "../readPackageVersion.js";
 import { createHappyMachineMetadata } from "./createHappyMachineMetadata.js";
 import { decryptHappyPayload, encryptHappyPayload, wrapHappyDataKey } from "./happyEncryption.js";
-import type { HappyConnectionConfiguration, HappySpawnSessionResult } from "./types.js";
+import type {
+    HappyConnectionConfiguration,
+    HappyListWorkspacesResult,
+    HappySpawnSessionResult,
+} from "./types.js";
 
 const HTTP_TIMEOUT_MS = 15_000;
 const RETRY_INTERVAL_MS = 5_000;
@@ -24,6 +28,13 @@ export interface HappyMachineClientOptions {
     modelCatalog: ModelCatalog;
     socketFactory?: (url: string, options: Parameters<typeof io>[1]) => HappyMachineSocket;
     spawnSession: (params: unknown, signal: AbortSignal) => Promise<HappySpawnSessionResult>;
+    /**
+     * Lists the managed workspaces of the project at a directory. Registered as
+     * its own machine RPC only when supplied — Happy discovers worktrees on a
+     * CLI machine by running git over the `bash` RPC, which Rig does not expose.
+     */
+    listWorkspaces?: (params: unknown) => Promise<HappyListWorkspacesResult>;
+    supportsWorktrees?: boolean;
 }
 
 export class HappyMachineClient {
@@ -33,6 +44,7 @@ export class HappyMachineClient {
     #metadataBase: Record<string, unknown> = {};
     readonly #socketFactory: NonNullable<HappyMachineClientOptions["socketFactory"]>;
     readonly #spawnSession: HappyMachineClientOptions["spawnSession"];
+    readonly #listWorkspaces: HappyMachineClientOptions["listWorkspaces"];
     #closed = false;
     readonly #closeController = new AbortController();
     #keepAliveTimer: NodeJS.Timeout | undefined;
@@ -49,6 +61,7 @@ export class HappyMachineClient {
         this.#socketFactory =
             options.socketFactory ?? ((url, socketOptions) => io(url, socketOptions) as Socket);
         this.#spawnSession = options.spawnSession;
+        this.#listWorkspaces = options.listWorkspaces;
     }
 
     close(): void {
@@ -127,6 +140,9 @@ export class HappyMachineClient {
         });
         socket.on("connect", () => {
             socket.emit("rpc-register", { method: `${machineId}:spawn-happy-session` });
+            if (this.#listWorkspaces !== undefined) {
+                socket.emit("rpc-register", { method: `${machineId}:list-happy-workspaces` });
+            }
             this.#syncMetadata(metadataVersion, 0);
             this.#syncDaemonState(daemonStateVersion, 0);
             this.#sendAlive();
@@ -146,12 +162,12 @@ export class HappyMachineClient {
         const machineId = this.#configuration.machineId!;
         const key = encryptionKey(this.#configuration);
         const variant = this.#configuration.credentials.encryption.type;
-        let response: HappySpawnSessionResult;
-        if (
-            !isRecord(request) ||
-            request.method !== `${machineId}:spawn-happy-session` ||
-            typeof request.params !== "string"
-        ) {
+        let response: HappySpawnSessionResult | HappyListWorkspacesResult;
+        const method = isRecord(request) ? request.method : undefined;
+        const isSpawn = method === `${machineId}:spawn-happy-session`;
+        const isList =
+            method === `${machineId}:list-happy-workspaces` && this.#listWorkspaces !== undefined;
+        if (!isRecord(request) || (!isSpawn && !isList) || typeof request.params !== "string") {
             response = { errorMessage: "Happy sent an invalid Rig request.", type: "error" };
         } else {
             const params = decryptHappyPayload(
@@ -163,7 +179,9 @@ export class HappyMachineClient {
                 response = { errorMessage: "Happy sent an unreadable Rig request.", type: "error" };
             } else {
                 try {
-                    response = await this.#spawnSession(params, this.#closeController.signal);
+                    response = isList
+                        ? await this.#listWorkspaces!(params)
+                        : await this.#spawnSession(params, this.#closeController.signal);
                 } catch (error) {
                     if (isDatabaseFailure(error)) throw error;
                     response = {

--- a/packages/rig/sources/happy/HappySessionClient.ts
+++ b/packages/rig/sources/happy/HappySessionClient.ts
@@ -16,6 +16,7 @@ import { readPackageVersion } from "../readPackageVersion.js";
 import { isPermissionMode } from "../permissions/index.js";
 import { withWorkerContext } from "../observability/index.js";
 import { rethrowDatabaseFailure } from "../persistence/rethrowDatabaseFailure.js";
+import { HAPPY_REMOTE_SESSION_WAIT_MS } from "../happySpawnTiming.js";
 import {
     createHappyAgentState,
     rememberHappyResolvedCommunication,
@@ -37,7 +38,7 @@ import type {
 } from "./types.js";
 
 const SYNC_RETRY_DELAY_MS = 2_000;
-const HTTP_TIMEOUT_MS = 15_000;
+const HTTP_TIMEOUT_MS = HAPPY_REMOTE_SESSION_WAIT_MS;
 const PAGE_SIZE = 100;
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 

--- a/packages/rig/sources/happy/HappySyncService.ts
+++ b/packages/rig/sources/happy/HappySyncService.ts
@@ -8,6 +8,7 @@ import type {
 } from "../protocol/index.js";
 import { isDatabaseFailure } from "../persistence/isDatabaseFailure.js";
 import { rethrowDatabaseFailure } from "../persistence/rethrowDatabaseFailure.js";
+import type { HappyWorkspaceCreationResult } from "../happySpawnTiming.js";
 import type { InMemorySession } from "../session/InMemorySession.js";
 import { HappyMachineClient } from "./HappyMachineClient.js";
 import {
@@ -47,7 +48,7 @@ export interface HappySyncServiceOptions {
     createWorkspace?: (
         ctx: Context,
         input: { directory: string; id: string; name: string; signal?: AbortSignal },
-    ) => Promise<{ id: string; path: string } | undefined>;
+    ) => Promise<HappyWorkspaceCreationResult | undefined>;
     /** Loads an idempotently-created session so a retried spawn can reuse its workspace. */
     loadSession?: (
         ctx: Context,

--- a/packages/rig/sources/happy/HappySyncService.ts
+++ b/packages/rig/sources/happy/HappySyncService.ts
@@ -17,6 +17,7 @@ import {
 } from "./HappySessionClient.js";
 import { HappySyncOutboxFullError, HappySyncRepository } from "./HappySyncRepository.js";
 import { HappyMessageMapper } from "./mapSessionEventToHappyMessages.js";
+import { handleHappyListWorkspaces } from "./handleHappyListWorkspaces.js";
 import { handleHappySpawnSession } from "./handleHappySpawnSession.js";
 import type { HappyConnectionConfiguration } from "./types.js";
 import type { Context } from "@steve.kite/stdlib";
@@ -42,6 +43,24 @@ export interface HappySyncServiceOptions {
         ctx: Context,
         session: InMemorySession,
     ) => HappyProjectContext | Promise<HappyProjectContext>;
+    /** Creates a managed workspace for a Happy machine-level spawn request. */
+    createWorkspace?: (
+        ctx: Context,
+        input: { directory: string; id: string; name: string; signal?: AbortSignal },
+    ) => Promise<{ id: string; path: string } | undefined>;
+    /** Loads an idempotently-created session so a retried spawn can reuse its workspace. */
+    loadSession?: (
+        ctx: Context,
+        sessionId: string,
+    ) => InMemorySession | Promise<InMemorySession | undefined> | undefined;
+    /** Lists the managed workspaces of the project at a directory for Happy's picker. */
+    listWorkspaces?: (
+        ctx: Context,
+        directory: string,
+    ) =>
+        | readonly { id: string; name: string; path: string; status: string }[]
+        | Promise<readonly { id: string; name: string; path: string; status: string }[] | undefined>
+        | undefined;
     modelCatalog?: ModelCatalog;
     socketFactory?: HappySessionClientOptions["socketFactory"];
 }
@@ -88,6 +107,19 @@ export class HappySyncService {
                     ...(options.socketFactory === undefined
                         ? {}
                         : { socketFactory: options.socketFactory }),
+                    supportsWorktrees: options.createWorkspace !== undefined,
+                    ...(options.listWorkspaces === undefined
+                        ? {}
+                        : {
+                              listWorkspaces: (params) =>
+                                  withWorkerContext("happy-machine-list-workspaces", (ctx) =>
+                                      handleHappyListWorkspaces({
+                                          listWorkspaces: (directory) =>
+                                              options.listWorkspaces!(ctx, directory),
+                                          params,
+                                      }),
+                                  ),
+                          }),
                     spawnSession: (params, signal) =>
                         withWorkerContext("happy-machine-spawn-session", (ctx) =>
                             handleHappySpawnSession({
@@ -95,6 +127,18 @@ export class HappySyncService {
                                     const session = await this.#createSession!(ctx, id, request);
                                     await this.attach(ctx, session);
                                 },
+                                ...(options.createWorkspace === undefined
+                                    ? {}
+                                    : {
+                                          createWorkspace: (input) =>
+                                              options.createWorkspace!(ctx, input),
+                                      }),
+                                ...(options.loadSession === undefined
+                                    ? {}
+                                    : {
+                                          loadSession: (sessionId) =>
+                                              options.loadSession!(ctx, sessionId),
+                                      }),
                                 machineId: options.configuration.machineId!,
                                 modelCatalog: options.modelCatalog!,
                                 params,

--- a/packages/rig/sources/happy/createHappyMachineMetadata.ts
+++ b/packages/rig/sources/happy/createHappyMachineMetadata.ts
@@ -2,6 +2,7 @@ import { homedir, hostname, platform } from "node:os";
 
 import type { ModelCatalog } from "../protocol/index.js";
 import { readPackageVersion } from "../readPackageVersion.js";
+import { HAPPY_SPAWN_PENDING_RETRY_AFTER_MS } from "../happySpawnTiming.js";
 import { createHappyCatalogMetadata } from "./createHappyCatalogMetadata.js";
 import { HAPPY_PERMISSION_MODES } from "./happyPermissionModes.js";
 import type { HappyConnectionConfiguration, HappyMachineMetadata } from "./types.js";
@@ -65,7 +66,7 @@ export function createHappyMachineMetadata(options: {
         },
         sessionCreation: {
             idempotencyKey: "clientRequestId",
-            pendingRetryAfterMs: 2_000,
+            pendingRetryAfterMs: HAPPY_SPAWN_PENDING_RETRY_AFTER_MS,
             resultKinds: ["success", "pending", "requestToApproveDirectoryCreation", "error"],
         },
         rigMetadataVersion: 1,

--- a/packages/rig/sources/happy/createHappyMachineMetadata.ts
+++ b/packages/rig/sources/happy/createHappyMachineMetadata.ts
@@ -10,6 +10,8 @@ export function createHappyMachineMetadata(options: {
     configuration: HappyConnectionConfiguration;
     modelCatalog: ModelCatalog;
     now?: () => number;
+    /** Advertised only when the daemon can actually create workspaces. */
+    supportsWorktrees?: boolean;
 }): HappyMachineMetadata {
     const { models, providers } = createHappyCatalogMetadata(options.modelCatalog);
     const defaultModel = models.find(
@@ -22,7 +24,11 @@ export function createHappyMachineMetadata(options: {
     const host = hostname();
     const detectedAt = (options.now ?? Date.now)();
     return {
-        capabilities: { newSession: true, resume: false, worktrees: false },
+        capabilities: {
+            newSession: true,
+            resume: false,
+            worktrees: options.supportsWorktrees === true,
+        },
         cliAvailability: {
             agy: false,
             claude: false,

--- a/packages/rig/sources/happy/createHappySpawnSessionId.ts
+++ b/packages/rig/sources/happy/createHappySpawnSessionId.ts
@@ -7,3 +7,18 @@ export function createHappySpawnSessionId(machineId: string, clientRequestId: st
         .update(clientRequestId)
         .digest("base64url")}`;
 }
+
+/**
+ * A deterministic cuid2-shaped identity for the workspace owned by one Happy
+ * spawn request. PersistentSessionStore uses a caller-supplied workspace ID as
+ * its idempotency key, so a retried machine RPC returns the first workspace.
+ */
+export function createHappySpawnWorkspaceId(machineId: string, clientRequestId: string): string {
+    return `w${createHash("sha256")
+        .update("happy-workspace\0")
+        .update(machineId)
+        .update("\0")
+        .update(clientRequestId)
+        .digest("hex")
+        .slice(0, 31)}`;
+}

--- a/packages/rig/sources/happy/handleHappyListWorkspaces.ts
+++ b/packages/rig/sources/happy/handleHappyListWorkspaces.ts
@@ -1,0 +1,59 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+import { Value } from "@sinclair/typebox/value";
+
+import { isDatabaseFailure } from "../persistence/isDatabaseFailure.js";
+import {
+    happyListWorkspacesRequestSchema,
+    type HappyListWorkspacesRequest,
+    type HappyListWorkspacesResult,
+    type HappyWorkspaceSummary,
+} from "./types.js";
+
+/**
+ * Answers Happy's worktree picker for a Rig machine.
+ *
+ * On a Happy CLI machine the picker discovers worktrees by running git through
+ * the `bash` RPC. Rig exposes no machine-level shell, so it reports the managed
+ * workspaces it already tracks instead — and reports them by project, since a
+ * workspace only means anything inside one.
+ */
+export async function handleHappyListWorkspaces(options: {
+    listWorkspaces: (
+        directory: string,
+    ) =>
+        | readonly HappyWorkspaceSummary[]
+        | Promise<readonly HappyWorkspaceSummary[] | undefined>
+        | undefined;
+    params: unknown;
+}): Promise<HappyListWorkspacesResult> {
+    try {
+        const directory = readDirectory(options.params);
+        const workspaces = await options.listWorkspaces(directory);
+        // A directory Rig has never opened is not a project yet, and therefore
+        // holds no workspaces — an empty list, not a failure.
+        return { type: "success", workspaces: workspaces ?? [] };
+    } catch (error) {
+        if (isDatabaseFailure(error)) throw error;
+        return {
+            errorMessage: error instanceof Error ? error.message : "Rig could not list workspaces.",
+            type: "error",
+        };
+    }
+}
+
+function readDirectory(value: unknown): string {
+    if (!Value.Check(happyListWorkspacesRequestSchema, value)) {
+        throw new Error("Happy must provide a directory.");
+    }
+    const directory = (value as HappyListWorkspacesRequest).directory.trim();
+    const expanded =
+        directory === "~"
+            ? homedir()
+            : directory.startsWith("~/")
+              ? resolve(homedir(), directory.slice(2))
+              : directory;
+    if (!expanded.startsWith("/")) throw new Error("The directory must be absolute.");
+    return resolve(expanded);
+}

--- a/packages/rig/sources/happy/handleHappySpawnSession.ts
+++ b/packages/rig/sources/happy/handleHappySpawnSession.ts
@@ -2,14 +2,37 @@ import { mkdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 
+import { Value } from "@sinclair/typebox/value";
+
 import { isPermissionMode } from "../permissions/index.js";
 import { isDatabaseFailure } from "../persistence/isDatabaseFailure.js";
 import type { CreateSessionRequest, ModelCatalog } from "../protocol/index.js";
-import { createHappySpawnSessionId } from "./createHappySpawnSessionId.js";
-import type { HappySpawnSessionRequest, HappySpawnSessionResult } from "./types.js";
+import {
+    createHappySpawnSessionId,
+    createHappySpawnWorkspaceId,
+} from "./createHappySpawnSessionId.js";
+import {
+    happySpawnSessionRequestSchema,
+    type HappySpawnSessionRequest,
+    type HappySpawnSessionResult,
+} from "./types.js";
 
 export async function handleHappySpawnSession(options: {
     createSession: (id: string, request: CreateSessionRequest) => void | Promise<void>;
+    /** Creates the deterministic managed workspace owned by this spawn request. */
+    createWorkspace?: (input: {
+        directory: string;
+        id: string;
+        name: string;
+        signal?: AbortSignal;
+    }) => Promise<{ id: string; path: string } | undefined>;
+    /** Loads an earlier attempt so a retry reuses its committed workspace. */
+    loadSession?: (
+        id: string,
+    ) =>
+        | { snapshot(): { cwd: string; workspaceId?: string } }
+        | Promise<{ snapshot(): { cwd: string; workspaceId?: string } } | undefined>
+        | undefined;
     machineId: string;
     modelCatalog: ModelCatalog;
     params: unknown;
@@ -52,9 +75,26 @@ export async function handleHappySpawnSession(options: {
             options.machineId,
             request.clientRequestId,
         );
+        const existingSession = (await options.loadSession?.(localSessionId))?.snapshot();
+        // Bind the session to its workspace from birth. Both identities derive
+        // from the RPC idempotency key, while an already-committed session lets
+        // an ordinary pending retry avoid even repeating workspace creation.
+        const workspace =
+            request.worktree === undefined
+                ? undefined
+                : existingSession === undefined
+                  ? await createRequestedWorkspace(
+                        directory,
+                        createHappySpawnWorkspaceId(options.machineId, request.clientRequestId),
+                        request.worktree.name,
+                        options.createWorkspace,
+                        options.signal,
+                    )
+                  : reuseRequestedWorkspace(existingSession);
         options.signal?.throwIfAborted();
         await options.createSession(localSessionId, {
-            cwd: directory,
+            cwd: workspace?.path ?? directory,
+            ...(workspace === undefined ? {} : { workspaceId: workspace.id }),
             effort,
             modelId,
             permissionMode,
@@ -78,33 +118,50 @@ export async function handleHappySpawnSession(options: {
     }
 }
 
+async function createRequestedWorkspace(
+    directory: string,
+    id: string,
+    name: string,
+    createWorkspace: Parameters<typeof handleHappySpawnSession>[0]["createWorkspace"],
+    signal?: AbortSignal,
+): Promise<{ id: string; path: string }> {
+    if (createWorkspace === undefined) {
+        throw new Error("This machine cannot create workspaces.");
+    }
+    const workspace = await createWorkspace({
+        directory,
+        id,
+        name,
+        ...(signal === undefined ? {} : { signal }),
+    });
+    if (workspace === undefined) {
+        throw new Error("Open this folder in Rig once before creating a workspace in it.");
+    }
+    return workspace;
+}
+
 function readRequest(value: unknown): HappySpawnSessionRequest {
-    if (!isRecord(value) || value.type !== "spawn-in-directory" || value.agent !== "rig") {
+    if (!Value.Check(happySpawnSessionRequestSchema, value)) {
+        if (
+            [...Value.Errors(happySpawnSessionRequestSchema, value)].some((error) =>
+                error.path.startsWith("/worktree"),
+            )
+        ) {
+            throw new Error("Happy sent an invalid worktree request.");
+        }
         throw new Error("Happy sent an unsupported Rig session request.");
     }
-    if (
-        typeof value.clientRequestId !== "string" ||
-        value.clientRequestId.trim().length === 0 ||
-        value.clientRequestId.length > 256
-    ) {
-        throw new Error("Happy must provide a client request ID.");
+    return value;
+}
+
+function reuseRequestedWorkspace(existing: { cwd: string; workspaceId?: string }): {
+    id: string;
+    path: string;
+} {
+    if (existing.workspaceId === undefined) {
+        throw new Error("This session request was already used without a workspace.");
     }
-    if (
-        typeof value.directory !== "string" ||
-        value.directory.trim().length === 0 ||
-        value.directory.length > 32_768
-    ) {
-        throw new Error("Happy must provide a session directory.");
-    }
-    for (const key of ["effort", "modelId", "permissionMode", "providerId"] as const) {
-        if (
-            value[key] !== undefined &&
-            (typeof value[key] !== "string" || value[key].length > 256)
-        ) {
-            throw new Error(`Happy sent an invalid ${key}.`);
-        }
-    }
-    return value as unknown as HappySpawnSessionRequest;
+    return { id: existing.workspaceId, path: existing.cwd };
 }
 
 function resolveDirectory(value: string): string {

--- a/packages/rig/sources/happy/handleHappySpawnSession.ts
+++ b/packages/rig/sources/happy/handleHappySpawnSession.ts
@@ -6,6 +6,10 @@ import { Value } from "@sinclair/typebox/value";
 
 import { isPermissionMode } from "../permissions/index.js";
 import { isDatabaseFailure } from "../persistence/isDatabaseFailure.js";
+import {
+    HAPPY_SPAWN_PENDING_RETRY_AFTER_MS,
+    type HappyWorkspaceCreationResult,
+} from "../happySpawnTiming.js";
 import type { CreateSessionRequest, ModelCatalog } from "../protocol/index.js";
 import {
     createHappySpawnSessionId,
@@ -25,7 +29,7 @@ export async function handleHappySpawnSession(options: {
         id: string;
         name: string;
         signal?: AbortSignal;
-    }) => Promise<{ id: string; path: string } | undefined>;
+    }) => Promise<HappyWorkspaceCreationResult | undefined>;
     /** Loads an earlier attempt so a retry reuses its committed workspace. */
     loadSession?: (
         id: string,
@@ -92,6 +96,13 @@ export async function handleHappySpawnSession(options: {
                     )
                   : reuseRequestedWorkspace(existingSession);
         options.signal?.throwIfAborted();
+        if (workspace?.type === "pending") {
+            return {
+                clientRequestId: request.clientRequestId,
+                retryAfterMs: workspace.retryAfterMs,
+                type: "pending",
+            };
+        }
         await options.createSession(localSessionId, {
             cwd: workspace?.path ?? directory,
             ...(workspace === undefined ? {} : { workspaceId: workspace.id }),
@@ -104,7 +115,7 @@ export async function handleHappySpawnSession(options: {
         if (remoteSessionId === undefined) {
             return {
                 clientRequestId: request.clientRequestId,
-                retryAfterMs: 2_000,
+                retryAfterMs: HAPPY_SPAWN_PENDING_RETRY_AFTER_MS,
                 type: "pending",
             };
         }
@@ -124,7 +135,7 @@ async function createRequestedWorkspace(
     name: string,
     createWorkspace: Parameters<typeof handleHappySpawnSession>[0]["createWorkspace"],
     signal?: AbortSignal,
-): Promise<{ id: string; path: string }> {
+): Promise<HappyWorkspaceCreationResult> {
     if (createWorkspace === undefined) {
         throw new Error("This machine cannot create workspaces.");
     }
@@ -157,11 +168,12 @@ function readRequest(value: unknown): HappySpawnSessionRequest {
 function reuseRequestedWorkspace(existing: { cwd: string; workspaceId?: string }): {
     id: string;
     path: string;
+    type: "ready";
 } {
     if (existing.workspaceId === undefined) {
         throw new Error("This session request was already used without a workspace.");
     }
-    return { id: existing.workspaceId, path: existing.cwd };
+    return { id: existing.workspaceId, path: existing.cwd, type: "ready" };
 }
 
 function resolveDirectory(value: string): string {

--- a/packages/rig/sources/happy/importHappyCredentials.ts
+++ b/packages/rig/sources/happy/importHappyCredentials.ts
@@ -28,9 +28,22 @@ export async function importHappyCredentials(
     const sourceSettings = await readJson(join(sourceHome, "settings.json"));
     let imported = false;
 
+    // The freshness gate below assumes source and target hold the same
+    // account, where the newer copy is the better one; a newer target also
+    // protects a direct `rig happy auth` login from being clobbered by a
+    // stale external home. Both assumptions break when HAPPY_HOME_DIR is set
+    // explicitly and names a different account: the user just said which
+    // account this daemon should use, and the cached copy being newer only
+    // records when it was cached. An explicit switch therefore always imports;
+    // the default ~/.happy keeps the protective freshness semantics.
+    const accountChanged =
+        Boolean(environment.HAPPY_HOME_DIR?.trim()) &&
+        holdsDifferentAccount(sourceCredentials, await readJson(targetPaths.credentialsPath));
+
     if (
         sourceCredentials !== undefined &&
-        (await isNewerThanTarget(join(sourceHome, "access.key"), targetPaths.credentialsPath))
+        (accountChanged ||
+            (await isNewerThanTarget(join(sourceHome, "access.key"), targetPaths.credentialsPath)))
     ) {
         try {
             const parsed = parseHappyCredentials(sourceCredentials);
@@ -42,7 +55,8 @@ export async function importHappyCredentials(
     }
     if (
         isRecord(sourceSettings) &&
-        (await isNewerThanTarget(join(sourceHome, "settings.json"), targetPaths.settingsPath))
+        (accountChanged ||
+            (await isNewerThanTarget(join(sourceHome, "settings.json"), targetPaths.settingsPath)))
     ) {
         try {
             await writeHappyJsonFile(targetPaths.settingsPath, sourceSettings);
@@ -75,6 +89,29 @@ export async function importHappyCredentials(
             ...(settingsServerUrl === undefined ? {} : { targetServerUrl: settingsServerUrl }),
         }),
     };
+}
+
+/**
+ * The encryption key is the account's identity: tokens rotate within an
+ * account, keys never do. Unreadable or malformed sides return false — the
+ * regular freshness gate and the malformed-source guard handle those.
+ */
+function holdsDifferentAccount(source: unknown, target: unknown): boolean {
+    const sourceIdentity = accountIdentity(source);
+    const targetIdentity = accountIdentity(target);
+    if (sourceIdentity === undefined || targetIdentity === undefined) return false;
+    return sourceIdentity !== targetIdentity;
+}
+
+function accountIdentity(value: unknown): string | undefined {
+    try {
+        const { stored } = parseHappyCredentials(value);
+        return stored.encryption === undefined
+            ? `legacy:${stored.secret}`
+            : `dataKey:${stored.encryption.publicKey}`;
+    } catch {
+        return undefined;
+    }
 }
 
 async function readJson(path: string): Promise<unknown | undefined> {

--- a/packages/rig/sources/happy/tests/HappyMachineClient.test.ts
+++ b/packages/rig/sources/happy/tests/HappyMachineClient.test.ts
@@ -25,7 +25,7 @@ const modelCatalog: ModelCatalog = {
 };
 
 describe("HappyMachineClient", () => {
-    it("registers a Rig-only machine and serves encrypted spawn RPC", async () => {
+    it("registers a Rig-only machine and serves encrypted spawn and workspace RPCs", async () => {
         const machineKey = new Uint8Array(32).fill(4);
         const configuration: HappyConnectionConfiguration = {
             credentials: {
@@ -51,7 +51,7 @@ describe("HappyMachineClient", () => {
                 Buffer.from(body.metadata!, "base64"),
             );
             expect(metadata).toMatchObject({
-                capabilities: { newSession: true, resume: false, worktrees: false },
+                capabilities: { newSession: true, resume: false, worktrees: true },
                 cliAvailability: { claude: false, codex: false, rig: true },
                 defaults: { permissionMode: "auto" },
                 machineKind: "rig",
@@ -77,15 +77,28 @@ describe("HappyMachineClient", () => {
             sessionId: "happy-session-1",
             type: "success" as const,
         }));
+        const listWorkspaces = vi.fn(async () => ({
+            type: "success" as const,
+            workspaces: [
+                {
+                    id: "workspace-1",
+                    name: "Steady River",
+                    path: "/workspace/steady-river",
+                    status: "ready",
+                },
+            ],
+        }));
         const client = new HappyMachineClient({
             configuration,
             fetch: request,
+            listWorkspaces,
             modelCatalog,
             socketFactory: (_url, options) => {
                 socket.options = options;
                 return socket;
             },
             spawnSession,
+            supportsWorktrees: true,
         });
 
         client.start();
@@ -98,6 +111,10 @@ describe("HappyMachineClient", () => {
         expect(socket.emitted).toContainEqual([
             "rpc-register",
             { method: "rig-machine-1:spawn-happy-session" },
+        ]);
+        expect(socket.emitted).toContainEqual([
+            "rpc-register",
+            { method: "rig-machine-1:list-happy-workspaces" },
         ]);
         const params = Buffer.from(
             encryptHappyPayload(machineKey, "dataKey", {
@@ -119,6 +136,31 @@ describe("HappyMachineClient", () => {
         expect(
             decryptHappyPayload(machineKey, "dataKey", Buffer.from(encryptedResponse, "base64")),
         ).toEqual({ sessionId: "happy-session-1", type: "success" });
+
+        const encryptedListResponse = await socket.requestRpc({
+            method: "rig-machine-1:list-happy-workspaces",
+            params: Buffer.from(
+                encryptHappyPayload(machineKey, "dataKey", { directory: "/workspace" }),
+            ).toString("base64"),
+        });
+        expect(listWorkspaces).toHaveBeenCalledWith({ directory: "/workspace" });
+        expect(
+            decryptHappyPayload(
+                machineKey,
+                "dataKey",
+                Buffer.from(encryptedListResponse, "base64"),
+            ),
+        ).toEqual({
+            type: "success",
+            workspaces: [
+                {
+                    id: "workspace-1",
+                    name: "Steady River",
+                    path: "/workspace/steady-river",
+                    status: "ready",
+                },
+            ],
+        });
         client.close();
     });
 });

--- a/packages/rig/sources/happy/tests/HappyMachineClient.test.ts
+++ b/packages/rig/sources/happy/tests/HappyMachineClient.test.ts
@@ -163,6 +163,87 @@ describe("HappyMachineClient", () => {
         });
         client.close();
     });
+
+    it("coalesces concurrent identical client requests before invoking the session creator", async () => {
+        const machineKey = new Uint8Array(32).fill(6);
+        const configuration: HappyConnectionConfiguration = {
+            credentials: {
+                encryption: { machineKey, publicKey: new Uint8Array(32).fill(7), type: "dataKey" },
+                token: "token",
+            },
+            credentialsPath: "/tmp/access.key",
+            happyHome: "/tmp/happy",
+            imported: false,
+            machineId: "rig-machine-concurrent",
+            serverUrl: "https://happy.example",
+        };
+        const socket = new FakeMachineSocket();
+        let resolveSpawn: ((result: { sessionId: string; type: "success" }) => void) | undefined;
+        const spawnResult = new Promise<{ sessionId: string; type: "success" }>((resolve) => {
+            resolveSpawn = resolve;
+        });
+        const spawnSession = vi.fn(async () => await spawnResult);
+        const client = new HappyMachineClient({
+            configuration,
+            fetch: async () =>
+                Response.json({ machine: { daemonStateVersion: 0, metadataVersion: 0 } }),
+            modelCatalog,
+            socketFactory: () => socket,
+            spawnSession,
+        });
+
+        client.start();
+        await waitFor(() => socket.connected);
+        const params = Buffer.from(
+            encryptHappyPayload(machineKey, "dataKey", {
+                agent: "rig",
+                clientRequestId: "same-request",
+                directory: "/workspace",
+                type: "spawn-in-directory",
+            }),
+        ).toString("base64");
+        const request = {
+            method: "rig-machine-concurrent:spawn-happy-session",
+            params,
+        };
+
+        const first = socket.requestRpc(request);
+        const second = socket.requestRpc(request);
+        await waitFor(() => spawnSession.mock.calls.length === 1);
+        if (resolveSpawn === undefined) throw new Error("Expected the spawn request to start.");
+        resolveSpawn({ sessionId: "happy-session-concurrent", type: "success" });
+
+        const [firstResponse, secondResponse] = await Promise.all([first, second]);
+        expect(
+            decryptHappyPayload(machineKey, "dataKey", Buffer.from(firstResponse, "base64")),
+        ).toEqual({ sessionId: "happy-session-concurrent", type: "success" });
+        expect(
+            decryptHappyPayload(machineKey, "dataKey", Buffer.from(secondResponse, "base64")),
+        ).toEqual({ sessionId: "happy-session-concurrent", type: "success" });
+        expect(spawnSession).toHaveBeenCalledOnce();
+
+        const changedParams = Buffer.from(
+            encryptHappyPayload(machineKey, "dataKey", {
+                agent: "rig",
+                clientRequestId: "same-request",
+                directory: "/different-workspace",
+                type: "spawn-in-directory",
+            }),
+        ).toString("base64");
+        const changedResponse = await socket.requestRpc({
+            method: "rig-machine-concurrent:spawn-happy-session",
+            params: changedParams,
+        });
+        expect(
+            decryptHappyPayload(machineKey, "dataKey", Buffer.from(changedResponse, "base64")),
+        ).toEqual({
+            errorMessage:
+                "This client request ID was already used for a different session request.",
+            type: "error",
+        });
+        expect(spawnSession).toHaveBeenCalledOnce();
+        client.close();
+    });
 });
 
 class FakeMachineSocket {

--- a/packages/rig/sources/happy/tests/handleHappyListWorkspaces.test.ts
+++ b/packages/rig/sources/happy/tests/handleHappyListWorkspaces.test.ts
@@ -1,0 +1,57 @@
+import { homedir } from "node:os";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { handleHappyListWorkspaces } from "../handleHappyListWorkspaces.js";
+
+describe("handleHappyListWorkspaces", () => {
+    it("normalizes the project directory and returns its managed workspaces", async () => {
+        const listWorkspaces = vi.fn(() => [
+            {
+                id: "workspace-1",
+                name: "Steady River",
+                path: `${homedir()}/project/.rig/workspaces/steady-river`,
+                status: "ready",
+            },
+        ]);
+
+        await expect(
+            handleHappyListWorkspaces({
+                listWorkspaces,
+                params: { directory: "~/project" },
+            }),
+        ).resolves.toEqual({
+            type: "success",
+            workspaces: [
+                {
+                    id: "workspace-1",
+                    name: "Steady River",
+                    path: `${homedir()}/project/.rig/workspaces/steady-river`,
+                    status: "ready",
+                },
+            ],
+        });
+        expect(listWorkspaces).toHaveBeenCalledWith(`${homedir()}/project`);
+    });
+
+    it("rejects relative and malformed requests before querying the store", async () => {
+        const listWorkspaces = vi.fn();
+
+        await expect(
+            handleHappyListWorkspaces({
+                listWorkspaces,
+                params: { directory: "relative/project" },
+            }),
+        ).resolves.toEqual({
+            errorMessage: "The directory must be absolute.",
+            type: "error",
+        });
+        await expect(
+            handleHappyListWorkspaces({ listWorkspaces, params: { directory: "   " } }),
+        ).resolves.toEqual({
+            errorMessage: "Happy must provide a directory.",
+            type: "error",
+        });
+        expect(listWorkspaces).not.toHaveBeenCalled();
+    });
+});

--- a/packages/rig/sources/happy/tests/handleHappySpawnSession.test.ts
+++ b/packages/rig/sources/happy/tests/handleHappySpawnSession.test.ts
@@ -6,6 +6,7 @@ import { isCuid } from "@paralleldrive/cuid2";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ModelCatalog } from "../../protocol/index.js";
+import { HAPPY_SPAWN_PENDING_RETRY_AFTER_MS } from "../../happySpawnTiming.js";
 import { createHappySpawnWorkspaceId } from "../createHappySpawnSessionId.js";
 import { handleHappySpawnSession } from "../handleHappySpawnSession.js";
 
@@ -117,6 +118,39 @@ describe("handleHappySpawnSession", () => {
         });
     });
 
+    it("returns pending without creating a session while a managed workspace is still preparing", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-workspace-pending-"));
+        directories.push(directory);
+        const createSession = vi.fn();
+        const waitForRemoteSession = vi.fn();
+
+        await expect(
+            handleHappySpawnSession({
+                createSession,
+                createWorkspace: async () => ({
+                    retryAfterMs: HAPPY_SPAWN_PENDING_RETRY_AFTER_MS,
+                    type: "pending" as const,
+                }),
+                machineId: "rig-machine",
+                modelCatalog: catalog,
+                params: {
+                    agent: "rig",
+                    clientRequestId: "mobile-request-workspace-pending",
+                    directory,
+                    type: "spawn-in-directory",
+                    worktree: { name: "steady-river", type: "new" },
+                },
+                waitForRemoteSession,
+            }),
+        ).resolves.toEqual({
+            clientRequestId: "mobile-request-workspace-pending",
+            retryAfterMs: HAPPY_SPAWN_PENDING_RETRY_AFTER_MS,
+            type: "pending",
+        });
+        expect(createSession).not.toHaveBeenCalled();
+        expect(waitForRemoteSession).not.toHaveBeenCalled();
+    });
+
     it("starts the session inside a workspace it creates for the request", async () => {
         const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-worktree-"));
         directories.push(directory);
@@ -124,6 +158,7 @@ describe("handleHappySpawnSession", () => {
         const createWorkspace = vi.fn(async () => ({
             id: "workspace-1",
             path: join(directory, ".rig", "workspaces", "clever-ocean"),
+            type: "ready" as const,
         }));
 
         await expect(
@@ -165,6 +200,7 @@ describe("handleHappySpawnSession", () => {
         const workspace = {
             id: "workspace-retried",
             path: join(directory, ".rig", "workspaces", "steady-river"),
+            type: "ready" as const,
         };
         const sessions = new Map<string, { snapshot(): { cwd: string; workspaceId?: string } }>();
         const createWorkspace = vi.fn(async () => workspace);

--- a/packages/rig/sources/happy/tests/handleHappySpawnSession.test.ts
+++ b/packages/rig/sources/happy/tests/handleHappySpawnSession.test.ts
@@ -2,9 +2,11 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { isCuid } from "@paralleldrive/cuid2";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ModelCatalog } from "../../protocol/index.js";
+import { createHappySpawnWorkspaceId } from "../createHappySpawnSessionId.js";
 import { handleHappySpawnSession } from "../handleHappySpawnSession.js";
 
 const directories: string[] = [];
@@ -113,6 +115,230 @@ describe("handleHappySpawnSession", () => {
             retryAfterMs: 2_000,
             type: "pending",
         });
+    });
+
+    it("starts the session inside a workspace it creates for the request", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-worktree-"));
+        directories.push(directory);
+        const createSession = vi.fn();
+        const createWorkspace = vi.fn(async () => ({
+            id: "workspace-1",
+            path: join(directory, ".rig", "workspaces", "clever-ocean"),
+        }));
+
+        await expect(
+            handleHappySpawnSession({
+                createSession,
+                createWorkspace,
+                machineId: "rig-machine",
+                modelCatalog: catalog,
+                params: {
+                    agent: "rig",
+                    clientRequestId: "mobile-request-worktree",
+                    directory,
+                    type: "spawn-in-directory",
+                    worktree: { name: "clever-ocean", type: "new" },
+                },
+                waitForRemoteSession: async () => "happy-session-worktree",
+            }),
+        ).resolves.toEqual({ sessionId: "happy-session-worktree", type: "success" });
+
+        const workspaceRequestId = createHappySpawnWorkspaceId(
+            "rig-machine",
+            "mobile-request-worktree",
+        );
+        expect(isCuid(workspaceRequestId)).toBe(true);
+        expect(createWorkspace).toHaveBeenCalledWith({
+            directory,
+            id: workspaceRequestId,
+            name: "clever-ocean",
+        });
+        expect(createSession.mock.calls[0]?.[1]).toMatchObject({
+            cwd: join(directory, ".rig", "workspaces", "clever-ocean"),
+            workspaceId: "workspace-1",
+        });
+    });
+
+    it("reuses one workspace when Happy retries the same spawn request", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-worktree-retry-"));
+        directories.push(directory);
+        const workspace = {
+            id: "workspace-retried",
+            path: join(directory, ".rig", "workspaces", "steady-river"),
+        };
+        const sessions = new Map<string, { snapshot(): { cwd: string; workspaceId?: string } }>();
+        const createWorkspace = vi.fn(async () => workspace);
+        const createSession = vi.fn(
+            (id: string, request: { cwd: string; workspaceId?: string }) => {
+                sessions.set(id, {
+                    snapshot: () => ({
+                        cwd: request.cwd,
+                        ...(request.workspaceId === undefined
+                            ? {}
+                            : { workspaceId: request.workspaceId }),
+                    }),
+                });
+            },
+        );
+        const options = {
+            createSession,
+            createWorkspace,
+            loadSession: (id: string) => sessions.get(id),
+            machineId: "rig-machine",
+            modelCatalog: catalog,
+            params: {
+                agent: "rig",
+                clientRequestId: "mobile-request-worktree-retry",
+                directory,
+                type: "spawn-in-directory",
+                worktree: { name: "steady-river", type: "new" },
+            },
+            waitForRemoteSession: async () => undefined,
+        } as const;
+
+        await handleHappySpawnSession(options);
+        await handleHappySpawnSession(options);
+
+        expect(createWorkspace).toHaveBeenCalledOnce();
+        expect(createSession).toHaveBeenCalledTimes(2);
+        expect(createSession.mock.calls[0]?.[1]).toMatchObject({
+            cwd: workspace.path,
+            workspaceId: workspace.id,
+        });
+        expect(createSession.mock.calls[1]?.[1]).toEqual(createSession.mock.calls[0]?.[1]);
+    });
+
+    it("does not add a workspace to a request already committed without one", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-worktree-conflict-"));
+        directories.push(directory);
+        const createWorkspace = vi.fn();
+
+        await expect(
+            handleHappySpawnSession({
+                createSession: vi.fn(),
+                createWorkspace,
+                loadSession: () => ({ snapshot: () => ({ cwd: directory }) }),
+                machineId: "rig-machine",
+                modelCatalog: catalog,
+                params: {
+                    agent: "rig",
+                    clientRequestId: "mobile-request-worktree-conflict",
+                    directory,
+                    type: "spawn-in-directory",
+                    worktree: { name: "steady-river", type: "new" },
+                },
+                waitForRemoteSession: async () => undefined,
+            }),
+        ).resolves.toEqual({
+            errorMessage: "This session request was already used without a workspace.",
+            type: "error",
+        });
+        expect(createWorkspace).not.toHaveBeenCalled();
+    });
+
+    it("refuses a worktree request on a machine that cannot create one", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-worktree-unsupported-"));
+        directories.push(directory);
+        const createSession = vi.fn();
+
+        await expect(
+            handleHappySpawnSession({
+                createSession,
+                machineId: "rig-machine",
+                modelCatalog: catalog,
+                params: {
+                    agent: "rig",
+                    clientRequestId: "mobile-request-worktree-unsupported",
+                    directory,
+                    type: "spawn-in-directory",
+                    worktree: { name: "clever-ocean", type: "new" },
+                },
+                waitForRemoteSession: async () => undefined,
+            }),
+        ).resolves.toEqual({
+            errorMessage: "This machine cannot create workspaces.",
+            type: "error",
+        });
+        expect(createSession).not.toHaveBeenCalled();
+    });
+
+    it("explains that a folder has to be a project before it can hold a workspace", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-worktree-unknown-"));
+        directories.push(directory);
+        const createSession = vi.fn();
+
+        await expect(
+            handleHappySpawnSession({
+                createSession,
+                createWorkspace: async () => undefined,
+                machineId: "rig-machine",
+                modelCatalog: catalog,
+                params: {
+                    agent: "rig",
+                    clientRequestId: "mobile-request-worktree-unknown",
+                    directory,
+                    type: "spawn-in-directory",
+                    worktree: { name: "clever-ocean", type: "new" },
+                },
+                waitForRemoteSession: async () => undefined,
+            }),
+        ).resolves.toEqual({
+            errorMessage: "Open this folder in Rig once before creating a workspace in it.",
+            type: "error",
+        });
+        expect(createSession).not.toHaveBeenCalled();
+    });
+
+    it("rejects a worktree request that carries no name", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-worktree-invalid-"));
+        directories.push(directory);
+
+        await expect(
+            handleHappySpawnSession({
+                createSession: vi.fn(),
+                createWorkspace: vi.fn(),
+                machineId: "rig-machine",
+                modelCatalog: catalog,
+                params: {
+                    agent: "rig",
+                    clientRequestId: "mobile-request-worktree-invalid",
+                    directory,
+                    type: "spawn-in-directory",
+                    worktree: { type: "new" },
+                },
+                waitForRemoteSession: async () => undefined,
+            }),
+        ).resolves.toEqual({
+            errorMessage: "Happy sent an invalid worktree request.",
+            type: "error",
+        });
+    });
+
+    it("rejects shell syntax in a worktree name before creating anything", async () => {
+        const directory = await mkdtemp(join(tmpdir(), "rig-happy-spawn-worktree-unsafe-"));
+        directories.push(directory);
+        const createWorkspace = vi.fn();
+
+        await expect(
+            handleHappySpawnSession({
+                createSession: vi.fn(),
+                createWorkspace,
+                machineId: "rig-machine",
+                modelCatalog: catalog,
+                params: {
+                    agent: "rig",
+                    clientRequestId: "mobile-request-worktree-unsafe",
+                    directory,
+                    type: "spawn-in-directory",
+                    worktree: { name: "safe; touch /tmp/pwned #", type: "new" },
+                },
+                waitForRemoteSession: async () => undefined,
+            }),
+        ).resolves.toEqual({
+            errorMessage: "Happy sent an invalid worktree request.",
+            type: "error",
+        });
+        expect(createWorkspace).not.toHaveBeenCalled();
     });
 
     it("does not downgrade a database failure to a Happy RPC error", async () => {

--- a/packages/rig/sources/happy/tests/importHappyCredentials.test.ts
+++ b/packages/rig/sources/happy/tests/importHappyCredentials.test.ts
@@ -131,6 +131,86 @@ describe("importHappyCredentials", () => {
         expect(imported?.credentials).toMatchObject({ token: "newer-rig-login" });
     });
 
+    it("imports an explicitly configured home that holds a different account, even when older", async () => {
+        const root = await mkdtemp(join(tmpdir(), "rig-happy-switch-"));
+        temporaryDirectories.push(root);
+        const home = join(root, "home");
+        const rigHome = join(home, ".happy", "rig");
+        const sourceHome = join(home, "dev-home");
+        const targetHome = join(rigHome, "happy");
+        await mkdir(sourceHome, { recursive: true });
+        await mkdir(targetHome, { recursive: true });
+        const source = {
+            secret: Buffer.alloc(32, 1).toString("base64"),
+            token: "dev-account",
+        };
+        const target = {
+            secret: Buffer.alloc(32, 2).toString("base64"),
+            token: "cached-prod-account",
+        };
+        const sourceCredentialsPath = join(sourceHome, "access.key");
+        const targetCredentialsPath = join(targetHome, "access.key");
+        await writeFile(sourceCredentialsPath, JSON.stringify(source));
+        await writeFile(targetCredentialsPath, JSON.stringify(target));
+        await utimes(sourceCredentialsPath, new Date(1_000), new Date(1_000));
+        await utimes(targetCredentialsPath, new Date(2_000), new Date(2_000));
+        await writeFile(
+            join(sourceHome, "settings.json"),
+            JSON.stringify({ serverUrl: "https://dev-account.example" }),
+        );
+        await writeFile(
+            join(targetHome, "settings.json"),
+            JSON.stringify({ serverUrl: "https://cached-prod.example" }),
+        );
+        await utimes(join(sourceHome, "settings.json"), new Date(1_000), new Date(1_000));
+        await utimes(join(targetHome, "settings.json"), new Date(2_000), new Date(2_000));
+
+        const imported = await importHappyCredentials({
+            environment: { HAPPY_HOME_DIR: sourceHome },
+            homeDirectory: home,
+            rigHome,
+        });
+
+        expect(imported).toMatchObject({
+            imported: true,
+            serverUrl: "https://dev-account.example",
+        });
+        expect(imported?.credentials).toMatchObject({ token: "dev-account" });
+    });
+
+    it("still protects a direct Rig login from an explicit home holding the same account", async () => {
+        const root = await mkdtemp(join(tmpdir(), "rig-happy-same-"));
+        temporaryDirectories.push(root);
+        const home = join(root, "home");
+        const rigHome = join(home, ".happy", "rig");
+        const sourceHome = join(home, "dev-home");
+        const targetHome = join(rigHome, "happy");
+        await mkdir(sourceHome, { recursive: true });
+        await mkdir(targetHome, { recursive: true });
+        const sharedSecret = Buffer.alloc(32, 1).toString("base64");
+        const sourceCredentialsPath = join(sourceHome, "access.key");
+        const targetCredentialsPath = join(targetHome, "access.key");
+        await writeFile(
+            sourceCredentialsPath,
+            JSON.stringify({ secret: sharedSecret, token: "older-token" }),
+        );
+        await writeFile(
+            targetCredentialsPath,
+            JSON.stringify({ secret: sharedSecret, token: "newer-token" }),
+        );
+        await utimes(sourceCredentialsPath, new Date(1_000), new Date(1_000));
+        await utimes(targetCredentialsPath, new Date(2_000), new Date(2_000));
+
+        const imported = await importHappyCredentials({
+            environment: { HAPPY_HOME_DIR: sourceHome },
+            homeDirectory: home,
+            rigHome,
+        });
+
+        expect(imported).toMatchObject({ imported: false });
+        expect(imported?.credentials).toMatchObject({ token: "newer-token" });
+    });
+
     it("keeps loading credentials when imported Happy settings cannot be written", async () => {
         const root = await mkdtemp(join(tmpdir(), "rig-happy-settings-write-"));
         temporaryDirectories.push(root);

--- a/packages/rig/sources/happy/tests/waitForHappyWorkspaceReady.test.ts
+++ b/packages/rig/sources/happy/tests/waitForHappyWorkspaceReady.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    HAPPY_MACHINE_RPC_TIMEOUT_MS,
+    HAPPY_REMOTE_SESSION_WAIT_MS,
+    HAPPY_SPAWN_PENDING_RETRY_AFTER_MS,
+    HAPPY_WORKSPACE_READY_WAIT_MS,
+    waitForHappyWorkspaceReady,
+} from "../../happySpawnTiming.js";
+
+describe("waitForHappyWorkspaceReady", () => {
+    it("returns the published pending response before Happy's 30-second machine RPC timeout", async () => {
+        let now = 0;
+        const result = await waitForHappyWorkspaceReady({
+            getWorkspace: () => ({
+                id: "workspace-1",
+                path: "/workspace/steady-river",
+                status: "initializing",
+            }),
+            now: () => now,
+            sleep: async (milliseconds) => {
+                now += milliseconds;
+            },
+        });
+
+        expect(result).toEqual({
+            retryAfterMs: HAPPY_SPAWN_PENDING_RETRY_AFTER_MS,
+            type: "pending",
+        });
+        expect(now).toBe(HAPPY_WORKSPACE_READY_WAIT_MS);
+        expect(HAPPY_REMOTE_SESSION_WAIT_MS).toBe(15_000);
+        expect(HAPPY_WORKSPACE_READY_WAIT_MS + HAPPY_REMOTE_SESSION_WAIT_MS).toBeLessThan(
+            HAPPY_MACHINE_RPC_TIMEOUT_MS,
+        );
+    });
+});

--- a/packages/rig/sources/happy/types.ts
+++ b/packages/rig/sources/happy/types.ts
@@ -1,3 +1,5 @@
+import { Type, type Static } from "@sinclair/typebox";
+
 import type { ToolCallPresentation } from "../agent/ToolCallPresentation.js";
 import type { SessionActivity } from "../protocol/index.js";
 
@@ -26,7 +28,8 @@ export interface HappyMachineMetadata {
     capabilities: {
         newSession: boolean;
         resume: false;
-        worktrees: false;
+        /** True only when the daemon was given a way to create managed workspaces. */
+        worktrees: boolean;
     };
     cliAvailability: {
         agy: false;
@@ -91,17 +94,61 @@ export interface HappyPublishedModel {
     value: string;
 }
 
-export interface HappySpawnSessionRequest {
-    agent: "rig";
-    approvedNewDirectoryCreation?: boolean;
-    clientRequestId: string;
-    directory: string;
-    effort?: string;
-    modelId?: string;
-    permissionMode?: string;
-    providerId?: string;
-    type: "spawn-in-directory";
+const boundedHappySelectionSchema = Type.String({ maxLength: 256 });
+
+export const happySpawnSessionRequestSchema = Type.Object(
+    {
+        agent: Type.Literal("rig"),
+        approvedNewDirectoryCreation: Type.Optional(Type.Boolean()),
+        clientRequestId: Type.String({ maxLength: 256, minLength: 1, pattern: "\\S" }),
+        directory: Type.String({ maxLength: 32_768, minLength: 1, pattern: "\\S" }),
+        effort: Type.Optional(boundedHappySelectionSchema),
+        modelId: Type.Optional(boundedHappySelectionSchema),
+        permissionMode: Type.Optional(boundedHappySelectionSchema),
+        providerId: Type.Optional(boundedHappySelectionSchema),
+        type: Type.Literal("spawn-in-directory"),
+        /**
+         * Asks for the session to run in a fresh managed workspace of the project at
+         * `directory` rather than in the directory itself. The intentionally narrow
+         * name is one portable branch/path segment and cannot be interpreted as shell.
+         */
+        worktree: Type.Optional(
+            Type.Object(
+                {
+                    name: Type.String({
+                        maxLength: 64,
+                        minLength: 1,
+                        pattern: "^[A-Za-z0-9](?:[A-Za-z0-9_-]|\\.(?=[A-Za-z0-9_-]))*$",
+                    }),
+                    type: Type.Literal("new"),
+                },
+                { additionalProperties: false },
+            ),
+        ),
+    },
+    { additionalProperties: false },
+);
+export type HappySpawnSessionRequest = Static<typeof happySpawnSessionRequestSchema>;
+
+export const happyListWorkspacesRequestSchema = Type.Object(
+    {
+        directory: Type.String({ maxLength: 32_768, minLength: 1, pattern: "\\S" }),
+    },
+    { additionalProperties: false },
+);
+export type HappyListWorkspacesRequest = Static<typeof happyListWorkspacesRequestSchema>;
+
+/** One managed workspace, in the shape Happy's worktree picker needs. */
+export interface HappyWorkspaceSummary {
+    id: string;
+    name: string;
+    path: string;
+    status: string;
 }
+
+export type HappyListWorkspacesResult =
+    | { type: "success"; workspaces: readonly HappyWorkspaceSummary[] }
+    | { errorMessage: string; type: "error" };
 
 export type HappySpawnSessionResult =
     | { sessionId: string; type: "success" }

--- a/packages/rig/sources/happy/types.ts
+++ b/packages/rig/sources/happy/types.ts
@@ -2,6 +2,7 @@ import { Type, type Static } from "@sinclair/typebox";
 
 import type { ToolCallPresentation } from "../agent/ToolCallPresentation.js";
 import type { SessionActivity } from "../protocol/index.js";
+export type { HappyWorkspaceCreationResult } from "../happySpawnTiming.js";
 
 export type HappyEncryptionVariant = "dataKey" | "legacy";
 

--- a/packages/rig/sources/happySpawnTiming.ts
+++ b/packages/rig/sources/happySpawnTiming.ts
@@ -1,0 +1,60 @@
+import { delay } from "./concurrency/index.js";
+
+/**
+ * Happy's machine RPC gateway expires calls after 30 seconds. A worktree spawn
+ * reserves 15 seconds for the session to be published remotely, leaving this
+ * bounded window for the local workspace checkout to become ready.
+ */
+export const HAPPY_MACHINE_RPC_TIMEOUT_MS = 30_000;
+export const HAPPY_REMOTE_SESSION_WAIT_MS = 15_000;
+export const HAPPY_WORKSPACE_READY_WAIT_MS = 8_000;
+export const HAPPY_SPAWN_PENDING_RETRY_AFTER_MS = 2_000;
+
+/** The local workspace preparation outcome that precedes a Happy spawn. */
+export type HappyWorkspaceCreationResult =
+    // Keep the ready discriminator optional for existing HappySyncService
+    // embedders that returned the pre-pending `{ id, path }` shape.
+    { id: string; path: string; type?: "ready" } | { retryAfterMs: number; type: "pending" };
+
+const WORKSPACE_POLL_INTERVAL_MS = 100;
+
+/**
+ * Wait only within the machine-RPC budget for a workspace reservation to be
+ * materialized. The reservation remains durable, so callers can safely retry
+ * the same client request after a pending result.
+ */
+export async function waitForHappyWorkspaceReady(options: {
+    getWorkspace: () =>
+        | { error?: string; id: string; path: string; status: string }
+        | Promise<{ error?: string; id: string; path: string; status: string } | undefined>
+        | undefined;
+    now?: () => number;
+    signal?: AbortSignal;
+    sleep?: (milliseconds: number, signal?: AbortSignal) => Promise<void>;
+}): Promise<HappyWorkspaceCreationResult> {
+    const now = options.now ?? Date.now;
+    const sleep = options.sleep ?? delay;
+    const deadline = now() + HAPPY_WORKSPACE_READY_WAIT_MS;
+    for (;;) {
+        options.signal?.throwIfAborted();
+        const workspace = await options.getWorkspace();
+        if (workspace === undefined) {
+            throw new Error("The workspace disappeared while it was being prepared.");
+        }
+        if (workspace.status === "ready") {
+            return { id: workspace.id, path: workspace.path, type: "ready" };
+        }
+        if (workspace.status !== "initializing") {
+            throw new Error(
+                workspace.error ?? `The workspace is ${workspace.status.replaceAll("_", " ")}.`,
+            );
+        }
+        if (now() >= deadline) {
+            return {
+                retryAfterMs: HAPPY_SPAWN_PENDING_RETRY_AFTER_MS,
+                type: "pending",
+            };
+        }
+        await sleep(Math.min(WORKSPACE_POLL_INTERVAL_MS, deadline - now()), options.signal);
+    }
+}

--- a/packages/rig/sources/server/runLocalProtocolServer.ts
+++ b/packages/rig/sources/server/runLocalProtocolServer.ts
@@ -45,7 +45,7 @@ import {
 import { createProviderUsageService } from "../executor/createProviderUsageService.js";
 import { createCredentialBindingUsageRouter } from "../executor/createCredentialBindingUsageRouter.js";
 import { loadConfiguredProviderUsage } from "../executor/loadConfiguredProviderUsage.js";
-import { gracefulShutdown } from "../concurrency/index.js";
+import { delay, gracefulShutdown } from "../concurrency/index.js";
 import { disableUnavailableProviders } from "../executor/disableUnavailableProviders.js";
 import { resolveProviderDisabledReasons } from "../executor/resolveProviderDisabledReasons.js";
 import { createCodingAssistantAgent } from "../runtime/createCodingAssistantAgent.js";
@@ -1246,6 +1246,12 @@ async function runOwnedLocalProtocolServer(
                                                                 ),
                                                         ),
                                                     ),
+                                                createWorkspace: (ctx, input) =>
+                                                    createReadyWorkspaceForHappy(
+                                                        ctx,
+                                                        store!,
+                                                        input,
+                                                    ),
                                                 databasePath: paths.databasePath,
                                                 getSubagents: async (ctx, sessionId) =>
                                                     (await store?.listSubagents(ctx, sessionId)) ??
@@ -1273,6 +1279,14 @@ async function runOwnedLocalProtocolServer(
                                                             : { workspace }),
                                                     };
                                                 },
+                                                listWorkspaces: (ctx, directory) =>
+                                                    listProjectWorkspacesForHappy(
+                                                        ctx,
+                                                        store!,
+                                                        directory,
+                                                    ),
+                                                loadSession: (ctx, sessionId) =>
+                                                    store!.get(ctx, sessionId),
                                                 modelCatalog,
                                             }),
                                     );
@@ -1468,6 +1482,8 @@ async function runOwnedLocalProtocolServer(
                                                               ),
                                                       ),
                                                   ),
+                                              createWorkspace: (ctx, input) =>
+                                                  createReadyWorkspaceForHappy(ctx, store!, input),
                                               databasePath: paths.databasePath,
                                               getSubagents: async (ctx, sessionId) =>
                                                   (await store?.listSubagents(ctx, sessionId)) ??
@@ -1495,6 +1511,14 @@ async function runOwnedLocalProtocolServer(
                                                           : { workspace }),
                                                   };
                                               },
+                                              listWorkspaces: (ctx, directory) =>
+                                                  listProjectWorkspacesForHappy(
+                                                      ctx,
+                                                      store!,
+                                                      directory,
+                                                  ),
+                                              loadSession: (ctx, sessionId) =>
+                                                  store!.get(ctx, sessionId),
                                               modelCatalog,
                                           });
                                       } catch (error) {
@@ -1560,6 +1584,59 @@ async function runOwnedLocalProtocolServer(
         });
     }
 }
+
+async function createReadyWorkspaceForHappy(
+    ctx: Context,
+    store: PersistentSessionStore,
+    input: { directory: string; id: string; name: string; signal?: AbortSignal },
+): Promise<{ id: string; path: string } | undefined> {
+    const settings = await store.queryProjectSettings(ctx, input.directory);
+    if (settings === undefined) return undefined;
+    const created = await store.createWorkspace(ctx, settings.projectId, {
+        id: input.id,
+        name: input.name,
+    });
+    if (created === undefined) return undefined;
+
+    const deadline = Date.now() + WORKSPACE_READY_TIMEOUT_MS;
+    for (;;) {
+        input.signal?.throwIfAborted();
+        const workspace = await store.getWorkspace(ctx, settings.projectId, created.id);
+        if (workspace === undefined) {
+            throw new Error("The workspace disappeared while it was being prepared.");
+        }
+        if (workspace.status === "ready") return { id: workspace.id, path: workspace.path };
+        if (workspace.status !== "initializing") {
+            throw new Error(
+                workspace.error ?? `The workspace is ${workspace.status.replaceAll("_", " ")}.`,
+            );
+        }
+        if (Date.now() > deadline) {
+            throw new Error("The workspace is still being prepared. Try again in a moment.");
+        }
+        await delay(WORKSPACE_POLL_INTERVAL_MS, input.signal);
+    }
+}
+
+async function listProjectWorkspacesForHappy(
+    ctx: Context,
+    store: PersistentSessionStore,
+    directory: string,
+): Promise<{ id: string; name: string; path: string; status: string }[] | undefined> {
+    const settings = await store.queryProjectSettings(ctx, directory);
+    if (settings === undefined) return undefined;
+    return (await store.listWorkspaces(ctx, settings.projectId))
+        .filter((workspace) => workspace.status === "ready")
+        .map((workspace) => ({
+            id: workspace.id,
+            name: workspace.name,
+            path: workspace.path,
+            status: workspace.status,
+        }));
+}
+
+const WORKSPACE_READY_TIMEOUT_MS = 60_000;
+const WORKSPACE_POLL_INTERVAL_MS = 100;
 
 function requirePluginManager(manager: PluginManager | undefined): PluginManager {
     if (manager === undefined)

--- a/packages/rig/sources/server/runLocalProtocolServer.ts
+++ b/packages/rig/sources/server/runLocalProtocolServer.ts
@@ -18,6 +18,10 @@ import { GitStateTracker } from "../git/GitStateTracker.js";
 import { getEnvironmentLocalServerPaths } from "./getEnvironmentLocalServerPaths.js";
 import { installDaemonProcessFailureLogging } from "./installDaemonProcessFailureLogging.js";
 import { loadHappyIntegration, type HappyIntegrationMode } from "./loadHappyIntegration.js";
+import {
+    waitForHappyWorkspaceReady,
+    type HappyWorkspaceCreationResult,
+} from "../happySpawnTiming.js";
 import { markGitStateFromSessionEvent } from "../git/markGitStateFromSessionEvent.js";
 import { publishGitLiveEvent } from "../git/publishGitLiveEvent.js";
 import { prepareLocalServerDirectory } from "./prepareLocalServerDirectory.js";
@@ -45,7 +49,7 @@ import {
 import { createProviderUsageService } from "../executor/createProviderUsageService.js";
 import { createCredentialBindingUsageRouter } from "../executor/createCredentialBindingUsageRouter.js";
 import { loadConfiguredProviderUsage } from "../executor/loadConfiguredProviderUsage.js";
-import { delay, gracefulShutdown } from "../concurrency/index.js";
+import { gracefulShutdown } from "../concurrency/index.js";
 import { disableUnavailableProviders } from "../executor/disableUnavailableProviders.js";
 import { resolveProviderDisabledReasons } from "../executor/resolveProviderDisabledReasons.js";
 import { createCodingAssistantAgent } from "../runtime/createCodingAssistantAgent.js";
@@ -1589,7 +1593,7 @@ async function createReadyWorkspaceForHappy(
     ctx: Context,
     store: PersistentSessionStore,
     input: { directory: string; id: string; name: string; signal?: AbortSignal },
-): Promise<{ id: string; path: string } | undefined> {
+): Promise<HappyWorkspaceCreationResult | undefined> {
     const settings = await store.queryProjectSettings(ctx, input.directory);
     if (settings === undefined) return undefined;
     const created = await store.createWorkspace(ctx, settings.projectId, {
@@ -1598,24 +1602,10 @@ async function createReadyWorkspaceForHappy(
     });
     if (created === undefined) return undefined;
 
-    const deadline = Date.now() + WORKSPACE_READY_TIMEOUT_MS;
-    for (;;) {
-        input.signal?.throwIfAborted();
-        const workspace = await store.getWorkspace(ctx, settings.projectId, created.id);
-        if (workspace === undefined) {
-            throw new Error("The workspace disappeared while it was being prepared.");
-        }
-        if (workspace.status === "ready") return { id: workspace.id, path: workspace.path };
-        if (workspace.status !== "initializing") {
-            throw new Error(
-                workspace.error ?? `The workspace is ${workspace.status.replaceAll("_", " ")}.`,
-            );
-        }
-        if (Date.now() > deadline) {
-            throw new Error("The workspace is still being prepared. Try again in a moment.");
-        }
-        await delay(WORKSPACE_POLL_INTERVAL_MS, input.signal);
-    }
+    return await waitForHappyWorkspaceReady({
+        getWorkspace: () => store.getWorkspace(ctx, settings.projectId, created.id),
+        ...(input.signal === undefined ? {} : { signal: input.signal }),
+    });
 }
 
 async function listProjectWorkspacesForHappy(
@@ -1634,9 +1624,6 @@ async function listProjectWorkspacesForHappy(
             status: workspace.status,
         }));
 }
-
-const WORKSPACE_READY_TIMEOUT_MS = 60_000;
-const WORKSPACE_POLL_INTERVAL_MS = 100;
 
 function requirePluginManager(manager: PluginManager | undefined): PluginManager {
     if (manager === undefined)


### PR DESCRIPTION
## Summary

Completes native Happy workspace support for Rig machines.

- Advertise worktree support only when managed workspace creation is available.
- Create and bind Happy sessions to deterministic Rig workspaces.
- Return pending workspace preparation before Happy's machine RPC timeout.
- Coalesce concurrent retries and reject reused request IDs with mismatched payloads.
- Expose encrypted workspace listing for the Happy picker, including after credential reloads.
- Validate Happy machine RPC payloads with TypeBox and reject unsafe workspace names.

## Validation

- `pnpm check`
- `pnpm --filter @slopus/rig test` (3319 tests)
- `pnpm format:check`
- `git diff --check`

Companion to the Happy changes in `Scoteezy:fix/harden-happy-session-flows`.