### PR TITLE
Add Claude Fable 5.1

### DIFF
--- a/packages/gym-tests/tests/happy_api_environment_onboarding_usage_matrix.test.ts
+++ b/packages/gym-tests/tests/happy_api_environment_onboarding_usage_matrix.test.ts
@@ -349,7 +349,7 @@ describe("Happy Agent onboarding and usage matrix", () => {
             expect(claude?.models).toEqual([
                 { id: "anthropic/opus-5", enabled: true },
                 { id: "anthropic/sonnet-5", enabled: false },
-                { id: "anthropic/fable-5", enabled: false },
+                { id: "anthropic/fable-5-1", enabled: false },
                 { id: "anthropic/opus-4-8", enabled: false },
             ]);
             expect(providers.find((provider) => provider.providerId === "codex")?.models).toEqual([

--- a/packages/happy-agent-modules/sources/config/impl/agentCatalog.ts
+++ b/packages/happy-agent-modules/sources/config/impl/agentCatalog.ts
@@ -51,7 +51,7 @@ export type ConfiguredAgentModel = AgentModel & {
 };
 
 const MODEL_CONTEXTS: Readonly<Record<string, AgentModelContext>> = Object.freeze({
-    "anthropic/fable-5": Object.freeze({
+    "anthropic/fable-5-1": Object.freeze({
         contextWindow: 1_000_000,
         autoCompactWindow: 333_000,
     }),
@@ -114,7 +114,7 @@ const CATALOG: readonly CatalogAgentModel[] = [
     model("codex", "openai/gpt-5.6-luna", "GPT-5.6 Luna", EVERY_EFFORT, "medium", ["priority"]),
     model("claude", "anthropic/opus-5", "Opus 5 1M"),
     model("claude", "anthropic/sonnet-5", "Sonnet 5"),
-    model("claude", "anthropic/fable-5", "Fable 5"),
+    model("claude", "anthropic/fable-5-1", "Fable 5.1", ALL_BUT_OFF, "high"),
     model("claude", "anthropic/opus-4-8", "Opus 4.8 1M"),
     model("grok", "xai/grok-4.6", "Grok 4.6", ["low", "medium", "high", "xhigh"], "high"),
     model("grok", "xai/grok-build", "Grok Build", ["medium"]),

--- a/packages/happy-agent-modules/sources/providerScan/ProviderScanModule.ts
+++ b/packages/happy-agent-modules/sources/providerScan/ProviderScanModule.ts
@@ -331,8 +331,8 @@ function verificationModel(
     providerId: string,
 ): AgentModel | undefined {
     const preferred: Readonly<Record<string, string>> = {
-        bedrock: "anthropic/fable-5",
-        claude: "anthropic/fable-5",
+        bedrock: "anthropic/fable-5-1",
+        claude: "anthropic/fable-5-1",
         codex: "openai/gpt-5.6-luna",
         grok: "xai/grok-composer-2.5-fast",
     };

--- a/packages/happy-agent-modules/sources/systemPrompt/impl/systemPromptForModel.ts
+++ b/packages/happy-agent-modules/sources/systemPrompt/impl/systemPromptForModel.ts
@@ -1,5 +1,6 @@
 import { Value } from "@sinclair/typebox/value";
 
+import { claude_fable_5_1_system_prompt } from "../prompts/claude/claude_fable_5_1_system_prompt.js";
 import { claude_fable_5_system_prompt } from "../prompts/claude/claude_fable_5_system_prompt.js";
 import { claude_opus_4_8_system_prompt } from "../prompts/claude/claude_opus_4_8_system_prompt.js";
 import { claude_opus_5_system_prompt } from "../prompts/claude/claude_opus_5_system_prompt.js";
@@ -16,6 +17,7 @@ import {
 const promptsByModel: Readonly<Record<string, string>> = Object.freeze({
     "anthropic/opus-5": claude_opus_5_system_prompt,
     "anthropic/sonnet-5": claude_sonnet_5_system_prompt,
+    "anthropic/fable-5-1": claude_fable_5_1_system_prompt,
     "anthropic/fable-5": claude_fable_5_system_prompt,
     "anthropic/opus-4-8": claude_opus_4_8_system_prompt,
 });

--- a/packages/happy-agent-modules/sources/systemPrompt/prompts/claude/claude_fable_5_1_system_prompt.ts
+++ b/packages/happy-agent-modules/sources/systemPrompt/prompts/claude/claude_fable_5_1_system_prompt.ts
@@ -1,0 +1,49 @@
+import { trimIndent } from "../../impl/trimIndent.js";
+
+export const claude_fable_5_1_system_prompt = trimIndent(`
+    {{identity}}
+    You are an interactive agent that helps users with software engineering tasks.
+
+    IMPORTANT: Assist with authorized security testing, defensive security, CTF challenges, and educational contexts. Refuse requests for destructive techniques, DoS attacks, mass targeting, supply chain compromise, or detection evasion for malicious purposes. Dual-use security tools (C2 frameworks, credential testing, exploit development) require clear authorization context: pentesting engagements, CTF competitions, security research, or defensive use cases.
+
+    # Harness
+     - Text you output outside of tool use is displayed to the user as Github-flavored markdown in a terminal.
+     - Tools run behind a user-selected permission mode; a denied call means the user declined it — adjust, don't retry verbatim.
+     - \`<system-reminder>\` tags in messages and tool results are injected by the harness, not the user. Hooks may intercept tool calls; treat hook output as user feedback.
+     - Prefer the dedicated file/search tools over shell commands when one fits. Independent tool calls can run in parallel in one response.
+     - Reference code as \`file_path:line_number\` — it's clickable.
+
+    # Communicating with the user
+
+    Your text output is what the user reads; they usually can't see your thinking or the raw tool results. Write it for a teammate who stepped away and is catching up, not for a log file: they don't know the codenames or shorthand you created along the way, and they didn't watch your process unfold. Before your first tool call, say in a sentence what you're about to do; while working, give brief updates when you find something load-bearing or change direction.
+
+    Text you write between tool calls may not be shown to the user. Everything the user needs from this turn — answers, summaries, findings, conclusions, deliverables — must be in the final text message of your turn, with no tool calls after it. Keep text between tool calls to brief status notes. If something important appeared only mid-turn or in your thinking, restate it in that final message.
+
+    Lead with the outcome. Your first sentence after finishing should answer "what happened" or "what did you find" — the thing the user would ask for if they said "just give me the TLDR." Supporting detail and reasoning come after, for readers who want them.
+
+    Being readable and being concise are different things, and readable matters more. If the user has to reread your summary or ask you to explain, any time saved by brevity is gone. The way to keep output short is to be selective about what you include (drop details that don't change what the reader would do next), not to compress the writing into fragments, abbreviations, arrow chains like \`A → B → fails\`, or jargon. What you do include, write in complete sentences with the technical terms spelled out. Don't make the reader cross-reference labels or numbering you invented earlier; say what you mean in place.
+
+    Match the response to the question: a simple question gets a direct answer in prose, not headers and sections. Use tables only for short enumerable facts, with explanations in the surrounding prose rather than the cells. Calibrate to the user — a bit tighter for an expert, more explanatory for someone newer.
+
+    Write code that reads like the surrounding code: match its comment density, naming, and idiom.
+    Only write a code comment to state a constraint the code itself can't show — never to say where it came from, what the next line does, or why your change is correct; that's you talking to the reviewer, not the next reader, and it's noise the moment the PR merges.
+
+    For actions that are hard to reverse or outward-facing, confirm first unless durably authorized or explicitly told to proceed without asking; approval in one context doesn't extend to the next. Sending content to an external service publishes it; it may be cached or indexed even if later deleted. Before deleting or overwriting, look at the target — if what you find contradicts how it was described, or you didn't create it, surface that instead of proceeding. Report outcomes faithfully: if tests fail, say so with the output; if a step was skipped, say that; when something is done and verified, state it plainly without hedging.
+
+    This iteration of Claude is Claude Fable 5.1. Claude Fable 5.1 extends Claude Fable 5 with stronger long-running agentic coding, multistep research, and document, spreadsheet, and slide work. Use it for demanding reasoning and long-horizon agentic work. Claude Mythos 5.1 offers the same capabilities by invitation only through Project Glasswing.
+
+    Knowledge cutoff: June 2026.
+
+    # Context management
+    When the conversation grows long, some or all of the current context is summarized; the summary, along with any remaining unsummarized context, is provided in the next context window so work can continue — you don't need to wrap up early or hand off mid-task.
+
+    When you have enough information to act, act. Do not re-derive facts already established in the conversation, re-litigate a decision the user has already made, or narrate options you will not pursue. If you are weighing a choice, give a recommendation, not an exhaustive survey
+
+    You are operating autonomously. The user is not watching in real time and cannot answer questions mid-task, so asking 'Want me to…?' or 'Shall I…?' will block the work. For reversible actions that follow from the original request, proceed without asking. Stop only for destructive actions or genuine scope changes the user must decide. Offering follow-ups after the task is done is fine; asking permission before doing the work is not.
+
+    Exception: when the user is describing a problem, asking a question, or thinking out loud rather than requesting a change, the deliverable is your assessment. Report your findings and stop. Don't apply a fix until they ask for one.
+
+    Before ending your turn, check your last paragraph. If it is a plan, an analysis, a question, a list of next steps, or a promise about work you have not done ('I'll…', 'let me know when…'), do that work now with tool calls. That includes retrying after errors and gathering missing information yourself. Do not stop because the context or session is long. End your turn only when the task is complete or you are blocked on input only the user can provide.
+
+    Before running a command that changes system state — restarts, deletes, config edits — check that the evidence actually supports that specific action. A signal that pattern-matches to a known failure may have a different cause.
+`);

--- a/packages/happy-agent-modules/sources/toolDiscovery/ToolDiscoveryModule.ts
+++ b/packages/happy-agent-modules/sources/toolDiscovery/ToolDiscoveryModule.ts
@@ -33,6 +33,7 @@ const CODEX_TOOL_SEARCH_DESCRIPTION =
 const CLAUDE_TOOL_SEARCH_MODELS = [
     "anthropic/opus-5",
     "anthropic/sonnet-5",
+    "anthropic/fable-5-1",
     "anthropic/fable-5",
     "anthropic/opus-4-8",
 ] as const;

--- a/packages/happy-agent-modules/tests/auto/reviewerModelForAgent.test.ts
+++ b/packages/happy-agent-modules/tests/auto/reviewerModelForAgent.test.ts
@@ -41,7 +41,7 @@ describe("reviewerModelForAgent", () => {
         const sonnetLevels: SessionReasoningEffort[] = ["off", "low", "medium", "high", "xhigh"];
         const models = [
             model("claude", "anthropic/opus-5", sonnetLevels, "medium"),
-            model("claude", "anthropic/fable-5", sonnetLevels, "medium"),
+            model("claude", "anthropic/fable-5-1", sonnetLevels, "medium"),
             model("claude", "anthropic/sonnet-5", sonnetLevels, "medium"),
         ];
 
@@ -49,7 +49,10 @@ describe("reviewerModelForAgent", () => {
             reviewerModelForAgent({ models, active: active("claude", "anthropic/opus-5", "high") }),
         ).toEqual({ providerId: "claude", modelId: "anthropic/sonnet-5", effort: "medium" });
         expect(
-            reviewerModelForAgent({ models, active: active("claude", "anthropic/fable-5", "low") }),
+            reviewerModelForAgent({
+                models,
+                active: active("claude", "anthropic/fable-5-1", "low"),
+            }),
         ).toEqual({ providerId: "claude", modelId: "anthropic/sonnet-5", effort: "medium" });
     });
 

--- a/packages/happy-agent-modules/tests/config/ConfigModule.test.ts
+++ b/packages/happy-agent-modules/tests/config/ConfigModule.test.ts
@@ -49,6 +49,31 @@ describe("ConfigModule", () => {
         });
     });
 
+    it("catalogs Fable 5.1 with its always-on adaptive thinking levels", async () => {
+        const root = await mkdtemp(join(tmpdir(), "happy-agent-config-fable-5-1-"));
+        temporaryDirectories.push(root);
+
+        const module = await ConfigModule.load(join(root, ".happy"));
+        const fable = module.catalog.find(
+            (candidate) =>
+                candidate.providerId === "claude" && candidate.id === "anthropic/fable-5-1",
+        );
+
+        expect(fable).toMatchObject({
+            autoCompactWindow: 333_000,
+            contextWindow: 1_000_000,
+            defaultEffort: "high",
+            effortLevels: ["low", "medium", "high", "xhigh", "max"],
+            name: "Fable 5.1",
+        });
+        expect(
+            module.catalog.some(
+                (candidate) =>
+                    candidate.providerId === "claude" && candidate.id === "anthropic/fable-5",
+            ),
+        ).toBe(false);
+    });
+
     it("loads Ethan mode from its nested machine setting", async () => {
         const root = await mkdtemp(join(tmpdir(), "happy-agent-config-ethan-"));
         temporaryDirectories.push(root);

--- a/packages/happy-agent-modules/tests/systemPrompt/SystemPromptModule.test.ts
+++ b/packages/happy-agent-modules/tests/systemPrompt/SystemPromptModule.test.ts
@@ -104,11 +104,15 @@ describe("SystemPromptModule", () => {
 
         const opus5 = await instructions(ctx, scopeOf("anthropic/opus-5", "claude"));
         const opus48 = await instructions(ctx, scopeOf("anthropic/opus-4-8", "claude"));
+        const fable51 = await instructions(ctx, scopeOf("anthropic/fable-5-1", "claude"));
         const codex = await instructions(ctx, scopeOf("openai/gpt-5.6-sol", "codex"));
 
         expect(opus5).toContain("mid-conversation system turns");
         expect(opus48).not.toContain("mid-conversation system turns");
+        expect(fable51).toContain("This iteration of Claude is Claude Fable 5.1.");
+        expect(fable51).toContain("Knowledge cutoff: June 2026.");
         expect(opus5).not.toBe(opus48);
+        expect(fable51).not.toBe(opus5);
         expect(codex).not.toBe(opus5);
         expect(codex.length).toBeGreaterThan(0);
     });

--- a/packages/happy-agent-modules/tests/toolDiscovery/ToolDiscoveryModule.test.ts
+++ b/packages/happy-agent-modules/tests/toolDiscovery/ToolDiscoveryModule.test.ts
@@ -5,6 +5,7 @@ import { ToolDiscoveryModule, toolDiscoveryTools } from "../../sources/toolDisco
 const CLAUDE_MODELS = [
     "anthropic/opus-5",
     "anthropic/sonnet-5",
+    "anthropic/fable-5-1",
     "anthropic/fable-5",
     "anthropic/opus-4-8",
 ] as const;

--- a/packages/happy-providers/package.json
+++ b/packages/happy-providers/package.json
@@ -46,7 +46,7 @@
     },
     "dependencies": {
         "@anthropic-ai/bedrock-sdk": "0.32.0",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.226",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.250",
         "@anthropic-ai/sdk": "0.110.0",
         "@aws-sdk/credential-provider-node": "3.972.71",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -67,14 +67,14 @@
         "vitest": "^3.2.4"
     },
     "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "^0.3.226",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "^0.3.226",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "^0.3.226",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "^0.3.226",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "^0.3.226",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "^0.3.226",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "^0.3.226",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "^0.3.226"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "^0.3.250",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "^0.3.250",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "^0.3.250",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "^0.3.250",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "^0.3.250",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "^0.3.250",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "^0.3.250",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "^0.3.250"
     },
     "engines": {
         "bun": ">=1.4.0",

--- a/packages/happy-providers/sources/vendors/bedrock/impl/resolveAnthropicBedrockModelId.ts
+++ b/packages/happy-providers/sources/vendors/bedrock/impl/resolveAnthropicBedrockModelId.ts
@@ -8,7 +8,7 @@ export function resolveAnthropicBedrockModelId(
     if (!model.startsWith("anthropic/")) return model;
     const modelName = model.slice("anthropic/".length);
     const base = `anthropic.claude-${modelName}`;
-    if (!["fable-5", "opus-5", "opus-4-8", "sonnet-5"].includes(modelName)) {
+    if (!["fable-5-1", "fable-5", "opus-5", "opus-4-8", "sonnet-5"].includes(modelName)) {
         throw new Error(
             `Anthropic model "${model}" is not available through Rig's Bedrock catalog. Pass a Bedrock model or inference-profile ID directly to use an unlisted model.`,
         );
@@ -23,7 +23,7 @@ export function resolveAnthropicBedrockModelId(
         if (region.startsWith("us-")) return `us.${base}`;
         return `global.${base}`;
     }
-    if (modelName === "fable-5") {
+    if (modelName === "fable-5-1" || modelName === "fable-5") {
         if (region.startsWith("eu-")) return `eu.${base}`;
         if (region.startsWith("us-")) return `us.${base}`;
         return `global.${base}`;

--- a/packages/happy-providers/sources/vendors/bedrock/impl/resolveBedrockModelId.ts
+++ b/packages/happy-providers/sources/vendors/bedrock/impl/resolveBedrockModelId.ts
@@ -1,4 +1,5 @@
 const BEDROCK_MODEL_IDS: Readonly<Record<string, string>> = {
+    "anthropic/fable-5-1": "anthropic.claude-fable-5-1",
     "anthropic/fable-5": "anthropic.claude-fable-5",
     "anthropic/opus-5": "anthropic.claude-opus-5",
     "anthropic/opus-4-8": "anthropic.claude-opus-4-8",

--- a/packages/happy-providers/sources/vendors/claude/impl/resolveClaudeModelId.ts
+++ b/packages/happy-providers/sources/vendors/claude/impl/resolveClaudeModelId.ts
@@ -1,4 +1,5 @@
 const CLAUDE_MODEL_IDS: Readonly<Record<string, string>> = {
+    "anthropic/fable-5-1": "claude-fable-5-1",
     "anthropic/fable-5": "claude-fable-5[1m]",
     "anthropic/opus-5": "claude-opus-5[1m]",
     "anthropic/opus-4-8": "claude-opus-4-8[1m]",

--- a/packages/happy-providers/tests/anthropicBedrockProvider.test.ts
+++ b/packages/happy-providers/tests/anthropicBedrockProvider.test.ts
@@ -180,6 +180,15 @@ describe("AnthropicBedrockProvider", () => {
         expect(resolveAnthropicBedrockModelId("anthropic/sonnet-5", "eu-west-1", "mantle")).toBe(
             "anthropic.claude-sonnet-5",
         );
+        expect(resolveAnthropicBedrockModelId("anthropic/fable-5-1", "us-east-1")).toBe(
+            "us.anthropic.claude-fable-5-1",
+        );
+        expect(resolveAnthropicBedrockModelId("anthropic/fable-5-1", "eu-west-1")).toBe(
+            "eu.anthropic.claude-fable-5-1",
+        );
+        expect(resolveAnthropicBedrockModelId("anthropic/fable-5-1", "us-east-1", "mantle")).toBe(
+            "anthropic.claude-fable-5-1",
+        );
         expect(resolveAnthropicBedrockModelId("custom-bedrock-profile", "us-east-1")).toBe(
             "custom-bedrock-profile",
         );

--- a/packages/happy-providers/tests/modelIds.test.ts
+++ b/packages/happy-providers/tests/modelIds.test.ts
@@ -9,6 +9,7 @@ import { resolveGrokModelId } from "@/vendors/grok/impl/resolveGrokModelId.js";
 describe("Rig model IDs", () => {
     it.each([
         [resolveClaudeModelId, "anthropic/sonnet-5", "claude-sonnet-5[1m]"],
+        [resolveClaudeModelId, "anthropic/fable-5-1", "claude-fable-5-1"],
         [resolveClaudeModelId, "anthropic/fable-5", "claude-fable-5[1m]"],
         [resolveClaudeModelId, "anthropic/opus-5", "claude-opus-5[1m]"],
         [resolveClaudeModelId, "anthropic/opus-4-8", "claude-opus-4-8[1m]"],
@@ -17,6 +18,7 @@ describe("Rig model IDs", () => {
         [resolveGrokModelId, "xai/grok-4.6", "grok-4.6"],
         [resolveGrokModelId, "xai/grok-4.5", "grok-4.5"],
         [resolveBedrockModelId, "anthropic/sonnet-5", "anthropic.claude-sonnet-5"],
+        [resolveBedrockModelId, "anthropic/fable-5-1", "anthropic.claude-fable-5-1"],
         [resolveBedrockModelId, "openai/gpt-5.6-sol", "openai.gpt-5.6-sol"],
     ])("resolves %s", (resolve, modelId, expected) => {
         expect(resolve(modelId)).toBe(expected);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,8 +458,8 @@ importers:
         specifier: 0.32.0
         version: 0.32.0(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.226
-        version: 0.3.226(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        specifier: ^0.3.250
+        version: 0.3.257(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: 0.110.0
         version: 0.110.0(zod@4.4.3)
@@ -511,29 +511,29 @@ importers:
         version: 3.2.6(@types/node@24.13.2)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
     optionalDependencies:
       '@anthropic-ai/claude-agent-sdk-darwin-arm64':
-        specifier: ^0.3.226
-        version: 0.3.226
+        specifier: ^0.3.250
+        version: 0.3.257
       '@anthropic-ai/claude-agent-sdk-darwin-x64':
-        specifier: ^0.3.226
-        version: 0.3.226
+        specifier: ^0.3.250
+        version: 0.3.257
       '@anthropic-ai/claude-agent-sdk-linux-arm64':
-        specifier: ^0.3.226
-        version: 0.3.226
+        specifier: ^0.3.250
+        version: 0.3.257
       '@anthropic-ai/claude-agent-sdk-linux-arm64-musl':
-        specifier: ^0.3.226
-        version: 0.3.226
+        specifier: ^0.3.250
+        version: 0.3.257
       '@anthropic-ai/claude-agent-sdk-linux-x64':
-        specifier: ^0.3.226
-        version: 0.3.226
+        specifier: ^0.3.250
+        version: 0.3.257
       '@anthropic-ai/claude-agent-sdk-linux-x64-musl':
-        specifier: ^0.3.226
-        version: 0.3.226
+        specifier: ^0.3.250
+        version: 0.3.257
       '@anthropic-ai/claude-agent-sdk-win32-arm64':
-        specifier: ^0.3.226
-        version: 0.3.226
+        specifier: ^0.3.250
+        version: 0.3.257
       '@anthropic-ai/claude-agent-sdk-win32-x64':
-        specifier: ^0.3.226
-        version: 0.3.226
+        specifier: ^0.3.250
+        version: 0.3.257
 
   packages/happy-terminal:
     dependencies:
@@ -664,8 +664,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.257':
+    resolution: {integrity: sha512-ITjFPYB8riu9tbxbrWArokiZ/90w/NDrYbtEvyr3ScilVtu1iupkComxkhvbUxoyT4JRDpKsdw/ZOfwSl/pkpA==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.226':
     resolution: {integrity: sha512-sOOCkhtMDGVKs6k3fpTAkCML974qOnt8Bm9zlC6rV0HkM0aP4bdDY1RAlKLF4fHmOP2s5fPTY3myZiHGDFnuUg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.257':
+    resolution: {integrity: sha512-0s7QoLRnopbMvCqVpgCnvBWg4UNxPUybMZTknkn3HLBMvUjUdHs1QXb77c/yrT1WAPqDTw1Ju+H0esXwWa8/Kg==}
     cpu: [x64]
     os: [darwin]
 
@@ -674,8 +684,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.257':
+    resolution: {integrity: sha512-t2WHfKjY4Jjgzfk0lbBUt6EVPQe+wXvXvRmYnK7ICfzZ1jS8CrpDajwBQErKFSMiUqGAutZy3vwDwGziW32cpw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.226':
     resolution: {integrity: sha512-YNwwC37m2vcY47mWZGqRmDh2ZSrO0Z01iTlIDsPmvKv03+7pwyaXVuq01Evtyp7see+KGeIYkMN37HhEt/h+8Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.257':
+    resolution: {integrity: sha512-38tv1s1CaIE6CyEBmJpfKtvwPzrasxPiRT079BEs5aaiLPQ+pmSGF0+Lwy7ot9i6xqr7v5/91TVo5JXHI8Pkpg==}
     cpu: [arm64]
     os: [linux]
 
@@ -684,8 +704,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.257':
+    resolution: {integrity: sha512-qSlgAUEpj2JAA+YqMD222iv2W3x8xBDSYwdoaOx20VbaJRjFq8feViI7kcr1C6wVN+ApX4Rxl7YX6gekiBkA2g==}
+    cpu: [x64]
+    os: [linux]
+
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.226':
     resolution: {integrity: sha512-gPoHNeko9E+bmKVPRiAcCAOyBBrVcIH/WdjmyaGVoTP2bKibTs978A42rMNtAnuPBcAGAiImQimUU7w1TXESFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.257':
+    resolution: {integrity: sha512-0FRyIwV4jEJErdDDoYMC0v9lzuFNz5y0lK2340H5fP02eNXsP3U0htKW/bfRP8Ppei+xc4QUZgdCI6rVzkhXGg==}
     cpu: [x64]
     os: [linux]
 
@@ -694,13 +724,31 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.257':
+    resolution: {integrity: sha512-7iEwy14lSqaAWvNR3KucBusQs5+hG6uoliYWZ2M2FyaCk5PHYymVf9mrRPtWhaYfNwum/YY13acYIIvnAbz0kA==}
+    cpu: [arm64]
+    os: [win32]
+
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.226':
     resolution: {integrity: sha512-uxVbLwGSX6lvO5Tazv0gZu8WSg1o14DQsqGSY+5pDNUk28KmNbFIQAjky9KeDzk9lnf63/aQPPsaq6UAikWjqA==}
     cpu: [x64]
     os: [win32]
 
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.257':
+    resolution: {integrity: sha512-NW0zMjHXFBdu2TcjT9Zo5o/1tJaDy6A7v4Gt/vLVJgaipV/RzAbyRGXZzH37hswyiKrSLGaSoYYP1vUfncbkUQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@anthropic-ai/claude-agent-sdk@0.3.226':
     resolution: {integrity: sha512-RvaZCZSKGjNIN/bDrQbyq/XkjVaUAPThxFrwFz2jdl6DvGnUtsGlt7hmPsaGC6BDudbA8yvkZFSqaJveK3WhfQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
+
+  '@anthropic-ai/claude-agent-sdk@0.3.257':
+    resolution: {integrity: sha512-Se55zXv48IYLg/WzoXzpbPLcq86suwDSbRUoNb69l4dkovorqS/47Xuy7MUo/gPNwwcPB4a+aqbXbshU33dcdQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -4067,25 +4115,49 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.226':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.257':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.226':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.257':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.226':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.257':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.226':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.257':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.226':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.257':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.226':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.257':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.226':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.257':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.226':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.257':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk@0.3.226(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
@@ -4102,6 +4174,21 @@ snapshots:
       '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.226
       '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.226
       '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.226
+
+  '@anthropic-ai/claude-agent-sdk@0.3.257(@anthropic-ai/sdk@0.110.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.110.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.257
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.257
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.257
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.257
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.257
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.257
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.257
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.257
 
   '@anthropic-ai/sdk@0.110.0(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- replace the curated Fable 5 choice with Fable 5.1 and its 1M context, always-on thinking efforts, and high default
- add native Claude and Bedrock model resolution while retaining legacy Fable 5 wire mappings
- update provider verification, ToolSearch selection, and the model-specific system prompt
- raise the bundled Claude Agent SDK minimum to 0.3.250; the lockfile resolves Claude Code 2.1.257

## Validation

- full workspace build on Node 24
- Happy Agent API build and consumer typecheck lane
- 118 focused provider, catalog, prompt, and discovery tests
- 13 onboarding and usage matrix gym tests from a short-path worktree
- package formatting checks and lint with zero errors
- bundled Claude Code executable reports 2.1.257

Closes #13