### PR TITLE
Retry the Claude Code keychain read across a credential rewrite

### DIFF
--- a/packages/happy-providers/sources/vendors/claude/impl/auth.ts
+++ b/packages/happy-providers/sources/vendors/claude/impl/auth.ts
@@ -7,6 +7,8 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const MACOS_KEYCHAIN_TIMEOUT_MS = 500;
+const MACOS_KEYCHAIN_ATTEMPTS = 3;
+const MACOS_KEYCHAIN_RETRY_DELAY_MS = 20;
 
 interface ClaudeCodeCredentials {
     claudeAiOauth?: {
@@ -61,7 +63,7 @@ export async function readClaudeCodeOAuthToken(
     }
 }
 
-async function readTokenFromMacOsKeychain(
+export async function readTokenFromMacOsKeychain(
     configDirectory: string,
     env: NodeJS.ProcessEnv,
 ): Promise<string | undefined> {
@@ -73,6 +75,30 @@ async function readTokenFromMacOsKeychain(
     const service = `Claude Code${oauthSuffix}-credentials${directorySuffix}`;
     const account = env.USER ?? userInfo().username;
 
+    // Claude Code stores a refreshed token with `security add-generic-password -U`, which deletes
+    // the item and adds it again. A read landing in that window fails with errSecItemNotFound for a
+    // credential that is present and valid, and `security` itself occasionally dies on a signal.
+    // Claude Code absorbs both behind a cache that keeps serving the last value it read; this
+    // function has no cache, so a single swallowed failure is reported to the caller as a missing
+    // credential. Retry instead, since the window closes within milliseconds.
+    for (let attempt = 1; attempt <= MACOS_KEYCHAIN_ATTEMPTS; attempt++) {
+        const token = await readTokenFromMacOsKeychainOnce(account, service);
+        if (token !== undefined) {
+            return token;
+        }
+
+        if (attempt < MACOS_KEYCHAIN_ATTEMPTS) {
+            await delay(MACOS_KEYCHAIN_RETRY_DELAY_MS * attempt);
+        }
+    }
+
+    return undefined;
+}
+
+async function readTokenFromMacOsKeychainOnce(
+    account: string,
+    service: string,
+): Promise<string | undefined> {
     try {
         const { stdout } = await execFileAsync(
             "security",
@@ -87,6 +113,10 @@ async function readTokenFromMacOsKeychain(
     } catch {
         return undefined;
     }
+}
+
+function delay(milliseconds: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function isFileNotFound(error: unknown): boolean {

--- a/packages/happy-providers/sources/vendors/claude/impl/auth.ts
+++ b/packages/happy-providers/sources/vendors/claude/impl/auth.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { homedir, userInfo } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -113,10 +114,6 @@ async function readTokenFromMacOsKeychainOnce(
     } catch {
         return undefined;
     }
-}
-
-function delay(milliseconds: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function isFileNotFound(error: unknown): boolean {

--- a/packages/happy-providers/tests/claudeKeychainCredential.test.ts
+++ b/packages/happy-providers/tests/claudeKeychainCredential.test.ts
@@ -1,0 +1,71 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readTokenFromMacOsKeychain } from "@/vendors/claude/impl/auth.js";
+
+const ACCESS_TOKEN = "keychain-access-token";
+const cleanups: (() => Promise<void>)[] = [];
+
+afterEach(async () => {
+    for (const cleanup of cleanups.splice(0)) await cleanup();
+});
+
+describe("Claude Code keychain credential", () => {
+    // Claude Code rewrites its credential with `security add-generic-password -U`, which deletes
+    // the item and adds it again. A read landing in that window reports errSecItemNotFound for a
+    // credential that is present and valid a moment later.
+    it("reads the token when the item is momentarily missing during a rewrite", async () => {
+        await installFakeSecurity({ failures: 1 });
+
+        await expect(readTokenFromMacOsKeychain(claudeConfigDir(), process.env)).resolves.toBe(
+            ACCESS_TOKEN,
+        );
+    });
+
+    it("reports no token once the keychain keeps failing", async () => {
+        await installFakeSecurity({ failures: Number.MAX_SAFE_INTEGER });
+
+        await expect(
+            readTokenFromMacOsKeychain(claudeConfigDir(), process.env),
+        ).resolves.toBeUndefined();
+    });
+});
+
+function claudeConfigDir(): string {
+    return join(tmpdir(), ".claude");
+}
+
+// Puts a `security` on PATH that fails the first `failures` calls the way the real one does when
+// the item is missing, so the read runs through the same child process it always does.
+async function installFakeSecurity(options: { failures: number }): Promise<void> {
+    const directory = await mkdtemp(join(tmpdir(), "claude-keychain-"));
+    const attempts = join(directory, "attempts");
+    const executable = join(directory, "security");
+
+    await writeFile(
+        executable,
+        [
+            "#!/bin/sh",
+            `attempts=$(cat ${attempts} 2>/dev/null || echo 0)`,
+            "attempts=$((attempts + 1))",
+            `echo "$attempts" > ${attempts}`,
+            `if [ "$attempts" -le ${options.failures} ]; then`,
+            "    echo 'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.' >&2",
+            "    exit 44",
+            "fi",
+            `echo '{"claudeAiOauth":{"accessToken":"${ACCESS_TOKEN}"}}'`,
+            "",
+        ].join("\n"),
+    );
+    await chmod(executable, 0o755);
+
+    const path = process.env.PATH;
+    process.env.PATH = `${directory}${delimiter}${path ?? ""}`;
+    cleanups.push(async () => {
+        process.env.PATH = path;
+        await rm(directory, { force: true, recursive: true });
+    });
+}


### PR DESCRIPTION
Fixes #15.

## The problem

Creating a session intermittently fails on the very first message with:

```
Claude authentication is unavailable for provider "claude".
```

Sending the same message again succeeds. The credential is valid throughout.

Claude Code stores a refreshed token with `security add-generic-password -U`, which deletes the
keychain item and adds it again. A read landing in that window fails with `errSecItemNotFound`
(exit 44) although the credential is present and valid, and `security` itself occasionally dies on
a signal. `readTokenFromMacOsKeychain` swallowed both, so `ClaudeCodeCredential.tryLoad` returned
`null` and `tryLoadCredentials` threw.

Only the first message can fail this way: the provider session is stateful and the credential is
resolved once, when the session is created.

Measured on macOS 15.6, reading a throwaway keychain item while it was being rewritten — 4 of 129
reads failed, none of them by timing out:

```
success = 125     FAILED = 4     reads >= 500ms = 0
  3 x exit 44   SecKeychainSearchCopyNext: The specified item could not be found in the keychain.
  1 x signal    security died on a signal
```

## The fix

Retry the read up to three times with a short backoff. The window closes within milliseconds, so
the first retry is enough in practice.

Claude Code absorbs the same failures behind a cache that keeps serving the last value it read.
This function has no cache, which is why a single swallowed failure surfaced to the user as a
missing credential.

`MACOS_KEYCHAIN_TIMEOUT_MS` is left at 500. The reads fail immediately rather than by timing out,
so raising it would not help and would only lengthen the worst case.

## Test

`tests/claudeKeychainCredential.test.ts` puts a `security` on `PATH` that fails the first call with
exit 44 exactly as the real one does when the item is missing, so the read runs through the same
child process it always does — no mocking of `execFile`.

The test fails on `main` (`expected undefined to be 'keychain-access-token'`) and passes with this
change, unmodified. A second case covers a keychain that keeps failing, which must still report no
token.

It is deterministic and platform-independent, so it runs on the Linux CI runner rather than being
skipped behind a `darwin` guard.

`readTokenFromMacOsKeychain` is exported so the test can reach it. It stays internal to the
package — `sources/index.ts` does not re-export it.

## Verification

Run locally on macOS 15.6. No workflow in the repository triggers on `pull_request`, so none of
this is checked by CI and it is worth re-running on your side:

- `pnpm --filter @slopus/happy-providers test` — 71 files, 570 tests pass
- `pnpm --filter @slopus/happy-providers check` — clean
- `oxlint` on both changed files — 0 warnings, 0 errors
- Formatted with `oxfmt`

## Cost of the retry

Exit 44 means both "the item is being rewritten" and "this user has no Claude Code credential",
and the two cannot be told apart from the exit code. A user who has not signed in to Claude Code
therefore pays for the retries on every credential resolve:

```
before   1 attempt    p50 = 17ms
after    3 attempts   p50 = 49ms + 60ms backoff  ~= 109ms
```

The success path is unchanged — one spawn, ~17ms — because the retry only runs after a failure.

Worth flagging separately: `fetchClaudeProviderUsage` reaches this function through
`readClaudeToken`, which sits outside its `AbortSignal.timeout` — that signal covers the HTTP
request only. Its worst case moves from 500ms to roughly 1560ms. Still bounded, but three times
longer, and quota observation is meant to carry explicit time bounds.

If that trade is unwelcome, two smaller variants are available: drop to two attempts, or retry only
when the child exits 44 rather than on any failure.

## Notes

Two things I left alone, happy to follow up if you would like them addressed:

1. `ClaudeCodeCredential.tryLoad` only probes whether a token can be read and then discards it —
   `credentialEnvironment` passes nothing on for `claude-code`, so the Claude Agent SDK reads the
   keychain again itself through its own cached path. The session was therefore refused because an
   unprotected existence check failed, not because the read that matters would have failed.
2. `catch {}` still discards the reason. Distinguishing "no credential is configured" from "the
   credential could not be read" would keep a transient keychain failure from being presented as a
   sign-out.
