### PR TITLE
Define queued message withdrawal API and client

### DIFF
--- a/packages/happy-agent-client/sources/HappyAgentClient.ts
+++ b/packages/happy-agent-client/sources/HappyAgentClient.ts
@@ -108,6 +108,8 @@ import type {
     MessageHistoryResponse,
     SendMessageRequest,
     SendMessageResponse,
+    WithdrawMessageRequest,
+    WithdrawMessageResponse,
 } from "./protocol/messages.js";
 import type { BackgroundProcessResponse } from "./protocol/processes.js";
 import type { ProfileResponse, ProfileUpdateRequest } from "./protocol/profile.js";
@@ -1566,6 +1568,21 @@ export class HappyAgentClient {
         return await this.#json({
             method: "POST",
             path: `v0/agents/${encodeURIComponent(agentId)}/send`,
+            json: request,
+            signal: options.signal,
+        });
+    }
+
+    /** `POST /v0/agents/:agentId/messages/:messageId/withdraw` — removes pending input. */
+    async withdrawMessage(
+        agentId: Cuid2,
+        messageId: Cuid2,
+        request: WithdrawMessageRequest = {},
+        options: RequestOptions = {},
+    ): Promise<WithdrawMessageResponse> {
+        return await this.#json({
+            method: "POST",
+            path: `v0/agents/${encodeURIComponent(agentId)}/messages/${encodeURIComponent(messageId)}/withdraw`,
             json: request,
             signal: options.signal,
         });

--- a/packages/happy-agent-client/sources/HappyReducerAgentReplica.ts
+++ b/packages/happy-agent-client/sources/HappyReducerAgentReplica.ts
@@ -244,6 +244,13 @@ export function reduceHappyReducerAgentEvent(
             fieldCursors = withFieldCursor(fieldCursors, "pending", event.cursor);
         }
     } else if (
+        event.type === "message.withdrawn" &&
+        event.payload.agentId === agent.id &&
+        event.cursor > fieldCursors.pending
+    ) {
+        state = withPending(state, removePending(state.pending, [event.payload.messageId]));
+        fieldCursors = withFieldCursor(fieldCursors, "pending", event.cursor);
+    } else if (
         (event.type === "run.started" || event.type === "run.boundary") &&
         event.payload.agentId === agent.id &&
         event.cursor > fieldCursors.pending

--- a/packages/happy-agent-client/sources/protocol/events.ts
+++ b/packages/happy-agent-client/sources/protocol/events.ts
@@ -248,6 +248,12 @@ export const messageDeltaPayloadSchema = Type.Object({
 /** Streaming text with an absolute prior-text offset. */
 export type MessageDeltaPayload = Static<typeof messageDeltaPayloadSchema>;
 
+/** A pending user message was withdrawn before inference accepted it. */
+export type MessageWithdrawnPayload = MutationEcho & {
+    agentId: Cuid2;
+    messageId: Cuid2;
+};
+
 /**
  * The message is gone from history.
  *
@@ -355,6 +361,7 @@ export type HappyAgentEvent =
     | EventEnvelope<"message.created", MessageCreatedPayload>
     | EventEnvelope<"message.updated", MessageUpdatedPayload>
     | EventEnvelope<"message.delta", MessageDeltaPayload>
+    | EventEnvelope<"message.withdrawn", MessageWithdrawnPayload>
     | EventEnvelope<"message.deleted", MessageDeletedPayload>
     | EventEnvelope<"config.updated", ConfigUpdatedPayload>
     | EventEnvelope<"profile.updated", ProfileUpdatedPayload>

--- a/packages/happy-agent-client/sources/protocol/messages.ts
+++ b/packages/happy-agent-client/sources/protocol/messages.ts
@@ -15,6 +15,7 @@ import {
     type Cuid2,
     type EventCursor,
     type MessageMode,
+    type MutationId,
     type Timestamp,
 } from "./common.js";
 import type { UsageBreakdown } from "./usage.js";
@@ -433,6 +434,18 @@ export interface SendMessageRequest {
 export interface SendMessageResponse {
     message: UserMessage;
     /** The event cursor at send; streaming from it replays everything this causes. */
+    cursor: EventCursor;
+}
+
+/** `POST /v0/agents/:agentId/messages/:messageId/withdraw` */
+export interface WithdrawMessageRequest {
+    /** Echoed on the event caused by the first successful withdrawal. */
+    mutationId?: MutationId;
+}
+
+/** `POST /v0/agents/:agentId/messages/:messageId/withdraw` */
+export interface WithdrawMessageResponse {
+    messageId: Cuid2;
     cursor: EventCursor;
 }
 

--- a/packages/happy-agent-client/tests/HappyAgentClient.test.ts
+++ b/packages/happy-agent-client/tests/HappyAgentClient.test.ts
@@ -532,6 +532,22 @@ describe("HappyAgentClient", () => {
         );
     });
 
+    it("withdraws one pending message and preserves both encoded identities", async () => {
+        const response = { cursor: "c2", messageId: "message/one" };
+        const { fetch, requests } = stubFetch(() => json(response));
+        const client = new HappyAgentClient({ endpoint: "http://agent.local", token: "t", fetch });
+
+        await expect(
+            client.withdrawMessage("agent/team", "message/one", { mutationId: "mutation-one" }),
+        ).resolves.toEqual(response);
+
+        expect(requests[0]?.url).toBe(
+            "http://agent.local/v0/agents/agent%2Fteam/messages/message%2Fone/withdraw",
+        );
+        expect(requests[0]?.method).toBe("POST");
+        expect(requests[0]?.body).toBe(JSON.stringify({ mutationId: "mutation-one" }));
+    });
+
     it("creates a user-visible agent with a different-workspace managing parent", async () => {
         const { fetch, requests } = stubFetch(() => json({ agent: {}, slashCommands: [] }, 201));
         const client = new HappyAgentClient({ endpoint: "http://agent.local", token: "t", fetch });

--- a/packages/happy-agent-client/tests/HappyReducerAgents.test.ts
+++ b/packages/happy-agent-client/tests/HappyReducerAgents.test.ts
@@ -240,6 +240,47 @@ describe("HappyReducer agent synchronization", () => {
         reducer.stop();
     });
 
+    it("removes only the pending message named by message.withdrawn", async () => {
+        const harness = new AgentReducerHarness();
+        const reducer = new HappyReducer(harness.client);
+        const first = userMessage("message-first", MODE_A);
+        const second = userMessage("message-second", MODE_B);
+        reducer.agentVisible(AGENT_A);
+        reducer.start();
+        harness.connect();
+        await vi.waitFor(() => expect(harness.startedAgentIds).toEqual([AGENT_A]));
+        harness.completeBootstrap(
+            AGENT_A,
+            agentBootstrap(AGENT_A, {
+                pending: [first, second],
+                processes: [],
+                subagents: [],
+            }),
+        );
+        await vi.waitFor(() =>
+            expect(reducer.getState().agents[AGENT_A]?.pending).toEqual([first, second]),
+        );
+
+        harness.stream.push(
+            eventUpdate({
+                cursor: CURSOR_2,
+                occurredAt: 2,
+                payload: {
+                    agentId: AGENT_A,
+                    messageId: second.id,
+                    mutationId: "mutation-withdraw-second",
+                },
+                type: "message.withdrawn",
+            }),
+        );
+
+        await vi.waitFor(() =>
+            expect(reducer.getState().agents[AGENT_A]?.pending).toEqual([first]),
+        );
+
+        reducer.stop();
+    });
+
     it("applies agent SSE updates with structural sharing", async () => {
         const harness = new AgentReducerHarness();
         const reducer = new HappyReducer(harness.client);

--- a/packages/happy-agent/API.md
+++ b/packages/happy-agent/API.md
@@ -157,13 +157,15 @@ start — see `POST /v0/agents/:agentId/send`.
 
 ### Archival, not deletion
 
-Nothing durable is ever permanently deleted through this API — that is deliberate, not an
-omission. Projects, workspaces, agents, and bots **archive**: they leave the active lists but keep
-their history and can be inspected. Only agents and bots can be unarchived for now; an archived project
-is revived by registering its path again, and an archived workspace stays archived. There are
-no hard-delete endpoints. The only things that end are runtime state — a terminal, a background process — and
-the transcript resets described under `message.deleted`, none of which is a client deleting a
-durable resource.
+Nothing in accepted history is ever permanently deleted through this API — that is deliberate,
+not an omission. Projects, workspaces, agents, and bots **archive**: they leave the active lists
+but keep their history and can be inspected. Only agents and bots can be unarchived for now; an
+archived project is revived by registering its path again, and an archived workspace stays
+archived. There are no hard-delete endpoints. A pending user message is the one exception: its
+sender may withdraw it before inference accepts it, because it has not entered a run or accepted
+history yet. The daemon retains its identity as a tombstone so a lost-response retry cannot
+resurrect it. The only other things that end are runtime state — a terminal, a background process
+— and the transcript resets described under `message.deleted`.
 
 ## Endpoints
 
@@ -3730,7 +3732,8 @@ Request:
   optimistic copy: whichever way the authoritative message arrives, it carries the ID the
   client already keys by. Omitted, the daemon generates one. Sending again with an `id` the
   agent already has creates nothing and returns the message as it now stands, which makes
-  retrying a send whose response was lost safe.
+  retrying a send whose response was lost safe. An ID whose pending message was withdrawn
+  remains reserved and returns `409` (`conflict`) instead of recreating the message.
 - `text` — the message text. Required.
 - `clientMetadata` — optional freeform JSON object owned by the sending client. It is persisted
   and echoed unchanged on every complete representation of this message, but is not interpreted
@@ -3816,6 +3819,37 @@ Response — `202`: the durable message as it now stands, plus the event cursor 
   the `runId` it brings is the handle for `abort`.
 - `cursor` — the event cursor at send; streaming from it replays everything this message
   causes, from its acceptance through its run's completion.
+
+### `POST /v0/agents/:agentId/messages/:messageId/withdraw`
+
+Withdraws one user message while it is still pending. Queue removal, the durable withdrawal
+tombstone, and the event commit atomically with respect to inference acceptance: exactly one side
+of the race wins. If withdrawal wins, the message never enters a run, disappears from every agent
+bootstrap, and never appears in message history. If acceptance wins, withdrawal returns `409`
+(`conflict`) and the accepted message remains unchanged.
+
+Request:
+
+```json
+{ "mutationId": "..." }
+```
+
+`mutationId` is optional and is echoed on the event caused by the first successful withdrawal.
+
+Response — `200`:
+
+```json
+{
+    "messageId": "tz4a98xxat96iws9zmbrgj3a",
+    "cursor": "01991f3a-6272-7000-8000-905162a30425"
+}
+```
+
+The first successful withdrawal emits one `message.withdrawn` event after the transaction
+commits. Repeating the same withdrawal is idempotent: it returns `200` with the message ID and the
+current event cursor, and emits no second event. The withdrawn ID stays reserved, so retrying the
+original send cannot put the message back. A message ID that never existed is `404`; a message
+already accepted into a run, or an ID belonging to any non-pending record, is `409` (`conflict`).
 
 ### `GET /v0/agents/:agentId/messages`
 
@@ -4912,6 +4946,13 @@ event is idempotent by attachment ID.
     - when the block is absent or not textual, the current text is shorter than `offset`, or text
       after `offset` conflicts with `append`, stop applying deltas for that message and reconcile
       it from authoritative history (or a later full `message.updated`).
+
+- `message.withdrawn` — a pending user message was withdrawn before inference accepted it.
+  Clients remove that ID from their pending composer queue. It never belongs to a run and is not
+  a transcript deletion.
+    - `agentId` (ID string).
+    - `messageId` (ID string).
+    - `mutationId` — echoed when the withdrawal request supplied one.
 
 - `message.deleted` — the message is gone from history; clients remove it from rendering.
   There is no REST operation behind this: deletion happens only when the daemon **resets a


### PR DESCRIPTION
First release stage for #17.

## What changes

- Defines POST /v0/agents/:agentId/messages/:messageId/withdraw as an additive API operation for pending user messages.
- Specifies durable tombstones, idempotent retries, 404/409 outcomes, and the message.withdrawn event.
- Adds the typed HappyAgentClient method and request/response/event contracts.
- Removes withdrawn IDs from reducer pending state.

## Release sequencing

This intentionally contains only the specification and client layer. Per the repository API release flow, @slopus/happy-agent-client must be merged and released before the follow-up core, daemon route, dependency, and integration changes are synced.

Expected next client release: 0.0.52.

## Verification

- @slopus/happy-agent-client typecheck passes.
- 40 focused client/reducer tests pass.
- The locally held follow-up implementation passes core checks and a daemon restart black-box scenario against these client types.